### PR TITLE
plot_centroids figure return

### DIFF
--- a/sectionproperties/analysis/cross_section.py
+++ b/sectionproperties/analysis/cross_section.py
@@ -1177,6 +1177,8 @@ class CrossSection:
         # finish the plot
         post.finish_plot(ax, pause, title='Centroids')
 
+        return fig, ax
+
     def display_mesh_info(self):
         """Prints mesh statistics (number of nodes, elements and regions) to the command window.
 

--- a/sectionproperties/examples/example_composite.py
+++ b/sectionproperties/examples/example_composite.py
@@ -44,7 +44,7 @@ stress_post = section.calculate_stress(N=-100e3, Mxx=-120e6, Vy=-75e3, time_info
 section.display_results()
 
 # plot the centroids
-section.plot_centroids()
+fig, ax = section.plot_centroids()
 
 stress_post.plot_stress_n_zz(pause=False)  # plot the axial stress
 stress_post.plot_stress_m_zz(pause=False)  # plot the bending stress

--- a/sectionproperties/examples/example_custom.py
+++ b/sectionproperties/examples/example_custom.py
@@ -33,4 +33,4 @@ section.calculate_warping_properties()
 section.calculate_plastic_properties()
 
 # plot the centroids
-section.plot_centroids()
+fig, ax = section.plot_centroids()

--- a/sectionproperties/examples/example_merged.py
+++ b/sectionproperties/examples/example_merged.py
@@ -39,4 +39,4 @@ section.calculate_warping_properties(time_info=True)
 section.calculate_plastic_properties(time_info=True, verbose=True)
 
 # plot the centroids
-section.plot_centroids()
+fig, ax = section.plot_centroids()

--- a/sectionproperties/examples/example_mirr_rot.py
+++ b/sectionproperties/examples/example_mirr_rot.py
@@ -33,4 +33,4 @@ section.calculate_warping_properties(time_info=True)
 section.calculate_plastic_properties(time_info=True, verbose=True)
 
 # plot the centroids
-section.plot_centroids()
+fig, ax = section.plot_centroids()


### PR DESCRIPTION
`CrossSection.plot_centroids()` now returns the plot figure and axes object.

Example scripts also updated to reflect this.

This PR should resolve Issue #27, allowing users more flexibility with the cross-section figure results. For example, adding points/arrows/circles to the figure, or saving the figure without relying on `plt.savefig(name)`, where the "current figure" isn't always correct.