### PR TITLE
[ImportDXF] - First attempt - NOT TO MERGE

### DIFF
--- a/sectionproperties/analysis/cross_section.py
+++ b/sectionproperties/analysis/cross_section.py
@@ -695,7 +695,7 @@ class CrossSection:
                 self.section_props.phi = 0
             else:
                 self.section_props.phi = np.arctan2(
-                    self.section_props.ixx_c - self.section_props.i11_c,
+                    self.section_props.ixx_c - i11_c,
                     self.section_props.ixy_c
                 ) * 180 / np.pi
 

--- a/sectionproperties/pre/sections.py
+++ b/sectionproperties/pre/sections.py
@@ -2305,21 +2305,36 @@ class ImportDXF(Geometry):
         else:
             UnitFact=1
 
-
-
         msp = doc.modelspace()
 
-        points=[]
-        facets=[]
+        points = []
+        facets = []
 
         for e in msp.query('LINE'):
-            points.append([e.dxf.start[0]*UnitFact,e.dxf.start[1]*UnitFact])
-            points.append([e.dxf.end[0]*UnitFact,e.dxf.end[1]*UnitFact])
-            facets.append([len(points)-2,len(points)-1])
+            points.append([e.dxf.start[0] * UnitFact, e.dxf.start[1] * UnitFact])
+            points.append([e.dxf.end[0] * UnitFact, e.dxf.end[1] * UnitFact])
+            facets.append([len(points) - 2, len(points) - 1])
 
         self.points = points
         self.facets = facets
-        self.holes = []
+
+        holes = []
+        if 'holes' in doc.layers:
+            for e in msp.query('POINT[layer=="holes"]'):
+                holes.append([e.dxf.location[0] * UnitFact, e.dxf.location[1] * UnitFact])
+        self.holes = holes
+
+        control_points = []
+        if 'control_points' in doc.layers:
+            for e in msp.query('POINT[layer=="control_points"]'):
+                control_points.append([e.dxf.location[0] * UnitFact, e.dxf.location[1] * UnitFact])
+            if not control_points:
+                err = "control_points layer does not contain any point. Check your *dxf file."
+                raise RuntimeError(err)
+        else:
+            err = "control_points layer not found. Check your *dxf file."
+            raise RuntimeError(err)
+        self.control_points = control_points
 
         self.shift_section()
 

--- a/sectionproperties/pre/sections.py
+++ b/sectionproperties/pre/sections.py
@@ -2263,3 +2263,4 @@ class MergedSection(Geometry):
             # add control points
             for control_point in section.control_points:
                 self.control_points.append([control_point[0], control_point[1]])
+                # test

--- a/sectionproperties/pre/sections.py
+++ b/sectionproperties/pre/sections.py
@@ -2383,3 +2383,25 @@ class ImportDXF(Geometry):
                     self.points.append([x_global, y_global])
 
                     self.facets.append([len(self.points) - 2, len(self.points) - 1])
+
+        if msp.query('CIRCLE') is not None:
+            for e in msp.query('CIRCLE'):
+
+                radius = e.dxf.radius * conversion_factor
+
+                ocs = e.ocs()
+                center = ocs.to_wcs(e.dxf.center) * conversion_factor
+
+                x = center[0] + radius * np.cos(0.0)
+                y = center[1] + radius * np.sin(0.0)
+                self.points.append([x, y])
+
+                for i in range(1, number_of_subdivisions + 1):
+
+                    current_angle = i * 2.0 * np.pi / number_of_subdivisions
+
+                    x = center[0] + radius * np.cos(current_angle)
+                    y = center[1] + radius * np.sin(current_angle)
+
+                    self.points.append([x, y])
+                    self.facets.append([len(self.points) - 2, len(self.points) - 1])

--- a/sectionproperties/pre/sections.py
+++ b/sectionproperties/pre/sections.py
@@ -2263,4 +2263,3 @@ class MergedSection(Geometry):
             # add control points
             for control_point in section.control_points:
                 self.control_points.append([control_point[0], control_point[1]])
-                # test

--- a/sectionproperties/pre/sections.py
+++ b/sectionproperties/pre/sections.py
@@ -2290,20 +2290,20 @@ class ImportDXF(Geometry):
             auditor.print_error_report()
 
         if(doc.header['$INSUNITS']==0):
-            UnitFact=1
+            conversion_factor=1
         elif(doc.header['$INSUNITS']==1): #en pouce
-            UnitFact=1*25.4/1000
+            conversion_factor=1*25.4/1000
 
         elif(doc.header['$INSUNITS']==2): #en feet
-            UnitFact=1*12*25.4/1000
+            conversion_factor=1*12*25.4/1000
         elif(doc.header['$INSUNITS']==4): #en mm
-            UnitFact=1/1000
+            conversion_factor=1/1000
         elif(doc.header['$INSUNITS']==5): #en cm
-            UnitFact=1/100
+            conversion_factor=1/100
         elif(doc.header['$INSUNITS']==6): #en m
-            UnitFact=1
+            conversion_factor=1
         else:
-            UnitFact=1
+            conversion_factor=1
 
         msp = doc.modelspace()
 
@@ -2311,8 +2311,8 @@ class ImportDXF(Geometry):
         facets = []
 
         for e in msp.query('LINE'):
-            points.append([e.dxf.start[0] * UnitFact, e.dxf.start[1] * UnitFact])
-            points.append([e.dxf.end[0] * UnitFact, e.dxf.end[1] * UnitFact])
+            points.append([e.dxf.start[0] * conversion_factor, e.dxf.start[1] * conversion_factor])
+            points.append([e.dxf.end[0] * conversion_factor, e.dxf.end[1] * conversion_factor])
             facets.append([len(points) - 2, len(points) - 1])
 
         self.points = points
@@ -2321,13 +2321,13 @@ class ImportDXF(Geometry):
         holes = []
         if 'holes' in doc.layers:
             for e in msp.query('POINT[layer=="holes"]'):
-                holes.append([e.dxf.location[0] * UnitFact, e.dxf.location[1] * UnitFact])
+                holes.append([e.dxf.location[0] * conversion_factor, e.dxf.location[1] * conversion_factor])
         self.holes = holes
 
         control_points = []
         if 'control_points' in doc.layers:
             for e in msp.query('POINT[layer=="control_points"]'):
-                control_points.append([e.dxf.location[0] * UnitFact, e.dxf.location[1] * UnitFact])
+                control_points.append([e.dxf.location[0] * conversion_factor, e.dxf.location[1] * conversion_factor])
             if not control_points:
                 err = "control_points layer does not contain any point. Check your *dxf file."
                 raise RuntimeError(err)
@@ -2340,8 +2340,8 @@ class ImportDXF(Geometry):
 
         for e in msp.query('ARC'):
 
-            self.draw_arc([e.dxf.center[0]*UnitFact, e.dxf.center[1]*UnitFact],
-                          e.dxf.radius*UnitFact,
+            self.draw_arc([e.dxf.center[0]*conversion_factor, e.dxf.center[1]*conversion_factor],
+                          e.dxf.radius*conversion_factor,
                           e.dxf.start_angle*np.pi/180,
                           e.dxf.end_angle*np.pi/180,
                           n=5)

--- a/sectionproperties/pre/sections.py
+++ b/sectionproperties/pre/sections.py
@@ -2289,21 +2289,21 @@ class ImportDXF(Geometry):
         if auditor.has_errors:
             auditor.print_error_report()
 
-        if(doc.header['$INSUNITS']==0):
-            conversion_factor=1
-        elif(doc.header['$INSUNITS']==1): #en pouce
-            conversion_factor=1*25.4/1000
-
-        elif(doc.header['$INSUNITS']==2): #en feet
-            conversion_factor=1*12*25.4/1000
-        elif(doc.header['$INSUNITS']==4): #en mm
-            conversion_factor=1/1000
-        elif(doc.header['$INSUNITS']==5): #en cm
-            conversion_factor=1/100
-        elif(doc.header['$INSUNITS']==6): #en m
-            conversion_factor=1
+        if(doc.header['$INSUNITS'] == 0):
+            conversion_factor = 1.
+        elif(doc.header['$INSUNITS'] == 1):
+            conversion_factor = 1. * 25.4
+        elif(doc.header['$INSUNITS'] == 2):
+            conversion_factor = 1. * 12 * 25.4
+        elif(doc.header['$INSUNITS'] == 4):
+            conversion_factor = 1.
+        elif(doc.header['$INSUNITS'] == 5):
+            conversion_factor = 10.
+        elif(doc.header['$INSUNITS'] == 6):
+            conversion_factor = 1000.
         else:
-            conversion_factor=1
+            print("WARNING: current unit of measure is not yet supported. Conversion factor set to 1!")
+            conversion_factor = 1.
 
         msp = doc.modelspace()
 

--- a/sectionproperties/pre/sections.py
+++ b/sectionproperties/pre/sections.py
@@ -1,8 +1,10 @@
+import sys
 import numpy as np
 import matplotlib.pyplot as plt
 import sectionproperties.pre.pre as pre
 import sectionproperties.post.post as post
 import ezdxf
+import ezdxf.recover as recover
 
 
 class Geometry:
@@ -2274,7 +2276,18 @@ class ImportDXF(Geometry):
 
         super().__init__(control_points, shift)
 
-        doc = ezdxf.readfile(File)
+        try:
+            doc, auditor = recover.readfile(File)
+        except IOError:
+            print(f'Not a DXF file or a generic I/O error.')
+            sys.exit(1)
+        except ezdxf.DXFStructureError:
+            print(f'Invalid or corrupted DXF file.')
+            sys.exit(2)
+
+        # DXF file can still have unrecoverable errors
+        if auditor.has_errors:
+            auditor.print_error_report()
 
         if(doc.header['$INSUNITS']==0):
             UnitFact=1

--- a/sectionproperties/pre/sections.py
+++ b/sectionproperties/pre/sections.py
@@ -2269,7 +2269,6 @@ class MergedSection(Geometry):
 class ImportDXF(Geometry):
 
 
-    # def __init__(self, points, facets, holes, control_points, shift=[0, 0]):
     def __init__(self, File,control_points=[[0,0]], shift=[0, 0]):
         """Inits the ImportDXF class."""
 
@@ -2301,7 +2300,6 @@ class ImportDXF(Geometry):
         facets=[]
 
         for e in msp.query('LINE'):
-            # print('posx:'+str(e.dxf.start[0])+'   posy:'+str(e.dxf.end))
             points.append([e.dxf.start[0]*UnitFact,e.dxf.start[1]*UnitFact])
             points.append([e.dxf.end[0]*UnitFact,e.dxf.end[1]*UnitFact])
             facets.append([len(points)-2,len(points)-1])
@@ -2312,26 +2310,10 @@ class ImportDXF(Geometry):
 
         self.shift_section()
 
-
-        """Adds a quarter radius of points to the points list - centered at
-        point *pt*, with radius *r*, starting at angle *theta*, with *n*
-        points. If r = 0, adds pt only.
-
-        :param pt: Centre of radius *(x,y)*
-        :type pt: list[float, float]
-        :param float r: Radius
-        :param float theta: Initial angle
-        :param int n: Number of points
-        :param bool anti: Anticlockwise rotation?
-        """
-        # self.plot_geometry()
         for e in msp.query('ARC'):
-            # print('start:'+str(e.dxf.start_angle)+'   stop:'+str(e.dxf.end_angle))
-
 
             self.draw_arc([e.dxf.center[0]*UnitFact, e.dxf.center[1]*UnitFact],
                           e.dxf.radius*UnitFact,
                           e.dxf.start_angle*np.pi/180,
                           e.dxf.end_angle*np.pi/180,
                           n=5)
-            # self.plot_geometry()

--- a/sectionproperties/pre/sections.py
+++ b/sectionproperties/pre/sections.py
@@ -2270,7 +2270,15 @@ class MergedSection(Geometry):
 
 
 class ImportDXF(Geometry):
+    """Import all the LINE, ARC and CIRCLE entities contained in one *.dxf file into one geometry.
+    Note that a layer "control_points" must be defined and must contains all the necessary control
+    points. In the same way holes control points, if any, must be defined in layer "holes".
+    Note that for the meshing algorithm to work, there needs to be connectivity between all
+    regions of the provided geometries. Overlapping of geometries is permitted.
 
+    :file: path/to/file.dxf
+    :integer number_of_subdivisions: number of segments in which ARC and CIRCLE are subdivided
+    """
 
     def __init__(self, file, number_of_subdivisions):
         """Inits the ImportDXF class."""

--- a/sectionproperties/pre/sections.py
+++ b/sectionproperties/pre/sections.py
@@ -2280,7 +2280,7 @@ class ImportDXF(Geometry):
     :integer number_of_subdivisions: number of segments in which ARC and CIRCLE are subdivided
     """
 
-    def __init__(self, file, number_of_subdivisions):
+    def __init__(self, file, number_of_subdivisions = 2):
         """Inits the ImportDXF class."""
 
         control_points = [[0, 0]]

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def readme():
 if sys.version_info[0] < 3 or sys.version_info[0] == 3 and sys.version_info[1] < 6:
     sys.exit('Sorry, Python < 3.6 is not supported')
 
-install_requires = ['numpy', 'scipy', 'matplotlib', 'shapely']
+install_requires = ['numpy', 'scipy', 'matplotlib', 'shapely', 'ezdxf']
 
 if not (sys.platform == 'win32' or sys.platform == 'cygwin'):
     install_requires.append('pybind11')

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def readme():
 if sys.version_info[0] < 3 or sys.version_info[0] == 3 and sys.version_info[1] < 6:
     sys.exit('Sorry, Python < 3.6 is not supported')
 
-install_requires = ['numpy', 'scipy', 'matplotlib', 'shapely', 'ezdxf']
+install_requires = ['numpy', 'scipy<=1.5', 'matplotlib', 'shapely', 'ezdxf']
 
 if not (sys.platform == 'win32' or sys.platform == 'cygwin'):
     install_requires.append('pybind11')


### PR DESCRIPTION
Here we go @robbievanleeuwen.
This PR add a `ImportDXF` class to `section.py` starting from the code posted by @Vinythewheel in https://github.com/robbievanleeuwen/section-properties/issues/10.
Few notes:

- holes, if any, must be defined as POINT in a layer called "holes";

- control_points are all the POINTs contained in the layer called "control_points". As it is, it is mandatory. However, we can load all the points defined in the dxf file except the ones in "holes", increasing the flexibility. To be agreed.

- I accidentally removed the `shift` option. Should I add it again? Is it required?

- POLYLINEs entities are not supported. Should we? To be agreed.

@Agent6-6-6 , @Vinythewheel your feedback is appreciated as well.

Kind regards,

Massimiliano


To do:

- [ ] add tests

- [ ] add documentation

- [ ] reach consensus about control_points

- [ ] reach consensus about POLYLINEs

- [ ] reach consensus about shift 