### PR TITLE
Matplotlib keywords fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@
 /dist/
 /build/
 
+# Commont virtual environments
+.venv/
+.env/
+
 # doc generated
 /docs/build
 
@@ -13,6 +17,10 @@
 
 # Pycharm IDE file folder
 /.idea/
+
+# vscode
+.vscode/
+*.code-workspace
 
 # mac
 .DS_Store

--- a/sectionproperties/pre/sections.py
+++ b/sectionproperties/pre/sections.py
@@ -304,17 +304,17 @@ class Geometry:
         for (i, h) in enumerate(self.holes):
             # plot the holes
             if i == 0:
-                ax.plot(h[0], h[1], 'rx', markerSize=5, label='Holes')
+                ax.plot(h[0], h[1], 'rx', markersize=5, label='Holes')
             else:
-                ax.plot(h[0], h[1], 'rx', markerSize=5)
+                ax.plot(h[0], h[1], 'rx', markersize=5)
 
         for (i, cp) in enumerate(self.control_points):
             # plot the control points
             if i == 0:
-                ax.plot(cp[0], cp[1], 'bo', markerSize=5,
+                ax.plot(cp[0], cp[1], 'bo', markersize=5,
                         label='Control Points')
             else:
-                ax.plot(cp[0], cp[1], 'bo', markerSize=5)
+                ax.plot(cp[0], cp[1], 'bo', markersize=5)
 
         # display the legend
         ax.legend(loc='center left', bbox_to_anchor=(1, 0.5))


### PR DESCRIPTION
Two changes:

- Ignore virtual environments and vscode file(s)
- Change matplotlib keyword argument from `markerSize` to `markersize` to fix this depreciation warning when using matplotlib 3.3.3:
    `MatplotlibDeprecationWarning: Case-insensitive properties were deprecated in 3.3 and support will be removed two minor releases later`
