### PR TITLE
add check_geometry function

### DIFF
--- a/sectionproperties/pre/pre.py
+++ b/sectionproperties/pre/pre.py
@@ -535,7 +535,7 @@ def check_geometry(points, facets, holes, control_points, atol=1.0e-8):
     check_points = np.array(holes + control_points)
 
     # select the starting and ending points of each facet
-    facet_points = points[facets]
+    facet_points = points[facets, :]
     start = facet_points[:, 0, :]
     end = facet_points[:, 1, :]
 
@@ -580,9 +580,9 @@ def check_geometry(points, facets, holes, control_points, atol=1.0e-8):
     minimum_distances = np.hypot(clamped_distances, perpendicular_distances)
 
     # make sure that the closest distance is not within the allowed tolerance
-    if np.min(minimum_distances) < tolerance:
+    if np.min(minimum_distances) < atol:
         # select the offending points and point type, then raise an exception with that information
-        distance_check = (minimum_distances < tolerance).sum(axis=0)
+        distance_check = (minimum_distances < atol).sum(axis=0)
         point_types = np.array(['Hole'] * len(holes) + ['Control Point'] * len(control_points))
         offending_types = point_types[distance_check > 0]
         offending_coords = check_points[distance_check > 0]

--- a/sectionproperties/pre/pre.py
+++ b/sectionproperties/pre/pre.py
@@ -2,6 +2,12 @@ import numpy as np
 import meshpy.triangle as triangle
 
 
+class GeometryError(Exception):
+    """Exception raised when invalid geometry is found."""
+
+    pass
+
+
 class Material:
     """Class for structural materials.
 
@@ -505,7 +511,100 @@ class GeometryCleaner:
             self.geometry.facets.pop(idx)
 
 
-def create_mesh(points, facets, holes, control_points, mesh_sizes):
+def check_geometry(points, facets, holes, control_points, tolerance=1.0e-7):
+    """Check that holes and control points do not lie on a facet line.
+
+    :param points: List of points *(x, y)* defining the vertices of the cross-section
+    :type points: list[list[float, float]]
+    :param facets: List of point index pairs *(p1, p2)* defining the edges of the cross-section
+    :type points: list[list[int, int]]
+    :param holes: List of points *(x, y)* defining the locations of holes within the cross-section.
+        If there are no holes, provide an empty list [].
+    :type holes: list[list[float, float]]
+    :param control_points: A list of points *(x, y)* that define different regions of the
+        cross-section. A control point is an arbitrary point within a region enclosed by facets.
+    :type control_points: list[list[float, float]]
+    :param tolerance: minimum permissable distance from facet
+    :type tolerance: float
+
+    General method was adapted from:
+    https://stackoverflow.com/a/54442561
+    """
+    # make sure points is a numpy array
+    points = np.asarray(points)
+    check_points = np.array(holes + control_points)
+
+    # select the starting and ending points of each facet
+    facet_points = points[facets]
+    start = facet_points[:, 0, :]
+    end = facet_points[:, 1, :]
+
+    # create the vectors for each facet and normalize them to unit vectors
+    facet_vectors = end - start
+    lengths = np.sqrt(np.einsum('ij,ij->i', facet_vectors, facet_vectors))
+    if np.any(lengths == 0.0):
+        # if a length is zero, then a facet had the same starting and ending
+        # point
+        facet_indices = np.nonzero(lengths == 0)[0]
+        offending_facets = facet_points[facet_indices]
+        facet_point_indices = np.array(facets)[facet_indices]
+        message = ''
+        for index, facet, point_indices in zip(
+            facet_indices, offending_facets, facet_point_indices
+        ):
+            message += (
+                f'\nFacet {index} with points {point_indices.tolist()} at '
+                f'{facet.tolist()}'
+            )
+        raise GeometryError(
+            f'{offending_facets.shape[0]} facets have the same starting and '
+            f'ending point:{message}'
+        )
+    unit_vectors = np.divide(facet_vectors, lengths.reshape(-1, 1))
+
+    # vectors from each point to check to the start and end of each facet
+    vec1 = np.array(check_points).reshape(1, -1, 2) - start.reshape(-1, 1, 2)
+    vec2 = np.array(check_points).reshape(1, -1, 2) - end.reshape(-1, 1, 2)
+
+    # signed parallel distance components
+    signed_parallel_vec1 = np.einsum('ijk,ik->ij', -vec1, unit_vectors)
+    signed_parallel_vec2 = np.einsum('ijk,ik->ij', vec2, unit_vectors)
+
+    # clamped parallel distance
+    clamped_distances = np.maximum.reduce(
+        [
+            signed_parallel_vec1,
+            signed_parallel_vec2,
+            np.zeros_like(signed_parallel_vec1),
+        ]
+    )
+
+    # calculate the cross product to get the perpendicular distance
+    perpendicular_distances = np.cross(vec1, unit_vectors.reshape(-1, 1, 2))
+
+    # get the minimum clamped distance
+    minimum_distances = np.hypot(clamped_distances, perpendicular_distances)
+
+    # make sure that the closest distance is not within the allowed tolerance
+    if np.min(minimum_distances) < tolerance:
+        # select the offending points and type of point, then raise an
+        # exception with that information
+        distance_check = (minimum_distances < tolerance).sum(axis=0)
+        point_types = np.array(
+            ['Hole'] * len(holes) + ['Control Point'] * len(control_points)
+        )
+        offending_types = point_types[distance_check > 0]
+        offending_coords = check_points[distance_check > 0]
+        message = ''
+        for point_type, coordinates in zip(offending_types, offending_coords):
+            message += f'\n{point_type} @ {coordinates}'
+        raise GeometryError(
+            f'{offending_coords.shape[0]} points are too close to a facet:'
+            f'{message}'
+        )
+
+
+def create_mesh(points, facets, holes, control_points, mesh_sizes, tolerance=1.0e-7):
     """Creates a quadratic triangular mesh using the meshpy module, which utilises the code
     'Triangle', by Jonathan Shewchuk.
 
@@ -525,6 +624,8 @@ def create_mesh(points, facets, holes, control_points, mesh_sizes):
     :return: Object containing generated mesh data
     :rtype: :class:`meshpy.triangle.MeshInfo`
     """
+
+    check_geometry(points, facets, holes, control_points, tolerance=tolerance)
 
     mesh = triangle.MeshInfo()  # create mesh info object
     mesh.set_points(points)  # set points


### PR DESCRIPTION
Fixes #38 

For the issue code there, this produces the exception:

    sectionproperties.pre.pre.GeometryError: 2 points are too close to a facet:
    Hole @ [-114.5    0. ]
    Hole @ [114.5   0. ]

I have not extensively tested this code, so more testing would be advised before merging this.  And if the move to `shapely` gets finished, then it looks like there would be a bit of a "nicer" way to do this too based on what @Agent6-6-6 suggested in that issue.  But this code is fully vectorized using numpy, so no python loops.

This new `check_geometry` function does 2 checks:

- Make sure that no facets have the same starting and ending point (length of zero) --- I assume that is invalid, but please confirm this
- Checks that no holes nor control points are within `tolerance` of a facet