### PR TITLE
Edits to the Creating Geometries, Meshes, and Material Properties docs

### DIFF
--- a/docs/source/rst/advanced_geom.rst
+++ b/docs/source/rst/advanced_geom.rst
@@ -1,6 +1,6 @@
 .. _label-advanced_geom:
 
-Advanced Geometry creation
+Advanced Geometry Creation
 ==========================
 
 The below tutorial was created to demonstrate the creation of valid geometries
@@ -22,7 +22,7 @@ Creating Merged Sections
 ------------------------
 
 For this example, we will create a custom section out of two similar "I" sections::
-    
+
     import sectionproperties.pre.sections as sections
     import sectionproperties.analysis.cross_section as cross_section
 
@@ -88,7 +88,7 @@ with ``sec_2`` taking precedence by being the first object in the operation::
 
 However, this is unsatisfactory as a solution. We want this section to more aptly represent a real section that might be created by cutting and welding two sections together.
 
-Lets say we want the upright "I" section to be our main section and the diagonal section will be added on to it. 
+Lets say we want the upright "I" section to be our main section and the diagonal section will be added on to it.
 
 It is sometimes possible to do this in a quick operation, one which does not create nodes in common at the intersection points.
 Here, we will simply "slice" ``i_sec2`` with ``i_sec1`` and add it to ``i_sec1``. This will create "floating nodes" along the
@@ -104,7 +104,7 @@ common edges of ``i_sec2`` and ``i_sec1`` because the nodes are not a part of ``
 ..  figure:: ../images/examples/combined_section_lucky_plot.png
     :align: center
     :scale: 50 %
-    
+
 Sometimes, we can get away with this as in this example. We can see in the plot that there are five distinct regions indicated with five control points.
 
 When we are "unlucky", sometimes gaps can be created (due to floating point errors) where the two sections meet and a proper hole might not be detected, resulting
@@ -151,5 +151,3 @@ And when we create our mesh and analysis section::
     :scale: 50 %
 
 We can see that the mesh represents how we expect the section to be.
-
-

--- a/docs/source/rst/examples.rst
+++ b/docs/source/rst/examples.rst
@@ -327,6 +327,8 @@ The following is printed to the terminal:
     Ixx + Iyy = 4.220
     J = 0.988
 
+.. _label-example-custom:
+
 Creating Custom Geometry
 ------------------------
 
@@ -403,9 +405,9 @@ Creating a Built-Up Section
 
 The following example demonstrates how to combine multiple geometry objects into
 a single geometry object. A 150x100x6 RHS is modelled with a solid 50x50 triangular
-section on its top and a 100x100x6 angle section on its right side. 
+section on its top and a 100x100x6 angle section on its right side.
 The three geometry objects are combined together as a :class:`~sectionproperties.pre.sections.CompoundGeometry`
-object using the `+` operator. 
+object using the `+` operator.
 
 To manipulate individual geometries into the final shape, there are a variety of
 methods available to move and align. This example uses `.align_center()`, `.align_to()`,

--- a/docs/source/rst/geom_mesh.rst
+++ b/docs/source/rst/geom_mesh.rst
@@ -6,113 +6,143 @@ Creating Geometries, Meshes, and Material Properties
 
 Before performing a cross-section analysis, the geometry of the cross-section and a finite element
 mesh must be created. Optionally, material properties can be applied to different regions of the
-cross-section. If materials are not applied, then a default material is used to report the geometric
-properties.
+cross-section. If materials are not applied, then a default material is used to report the
+geometric properties.
 
 
 Section Geometry
 ================
 
-**New in v2.0.0**
-There are two types of geometry objects in sectionproperties:
+**New in** ``v2.0.0`` - There are two types of geometry objects in sectionproperties:
 
-* The :class:`~sectionproperties.pre.sections.Geometry` class, for section geometries with a single, contiguous region
-* The :class:`~sectionproperties.pre.sections.CompoundGeometry` class, comprised of two or more `Geometry` objects
+* The :class:`~sectionproperties.pre.sections.Geometry` class, for section geometries with a
+  single, contiguous region
+* The :class:`~sectionproperties.pre.sections.CompoundGeometry` class, comprised of two or more
+  `Geometry` objects
 
-A :class:`~sectionproperties.pre.sections.Geometry` is instantiated with two arguments: 
+Geometry Class
+--------------
 
-#. A shapely.geometry.Polygon object
+..  autoclass:: sectionproperties.pre.sections.Geometry
+   :noindex:
+
+A :class:`~sectionproperties.pre.sections.Geometry` is instantiated with two arguments:
+
+#. A :class:`shapely.geometry.Polygon` object
 #. An optional :class:`~sectionproperties.pre.pre.Material` object
 
 .. note::
-   If a Material is not given, then the default material is assigned to the `Geometry.material` attribute
+   If a :class:`~sectionproperties.pre.pre.Material` is not given, then the default material is
+   assigned to the ``Geometry.material`` attribute. The default material has an elastic modulus of
+   1, a Poisson's ratio of 0 and a yield strength of 1.
 
-A :class:`~sectionproperties.pre.sections.CompoundGeometry` is instantiated with **one argument** which can be one of **two types**:
-#. A list of :class:`~sectionproperties.pre.sections.Geometry`; or
-#. A shapely.geometry.MultiPolygon
+CompoundGeometry Class
+----------------------
+
+..  autoclass:: sectionproperties.pre.sections.CompoundGeometry
+   :noindex:
+
+A :class:`~sectionproperties.pre.sections.CompoundGeometry` is instantiated with **one argument**
+which can be one of **two types**:
+
+#. A list of :class:`~sectionproperties.pre.sections.Geometry` objects; or
+#. A :class:`shapely.geometry.MultiPolygon`
 
 .. note::
-   A CompoundGeometry does not have a `.material` attribute and a :class:`~sectionproperties.pre.pre.Material`
-   cannot be assigned to a CompoundGeometry directly. Since a CompoundGeometry is simply a combination of Geometry objects,
-   the Material(s) should be assigned to the individual Geometry objects that comprise the CompoundGeometry. CompoundGeoemtry
-   objects created from a `shapely.geometry.MultiPolygon` will have its constituent Geometry objects assigned the default material.
+   A :class:`~sectionproperties.pre.sections.CompoundGeometry` does not have a ``.material``
+   attribute and therefore, a :class:`~sectionproperties.pre.pre.Material` cannot be assigned to a
+   :class:`~sectionproperties.pre.sections.CompoundGeometry` directly. Since a
+   :class:`~sectionproperties.pre.sections.CompoundGeometry` is simply a combination of
+   :class:`~sectionproperties.pre.sections.Geometry` objects, the Material(s) should be assigned to
+   the individual :class:`~sectionproperties.pre.sections.Geometry` objects that comprise the
+   :class:`~sectionproperties.pre.sections.CompoundGeometry`.
+   :class:`~sectionproperties.pre.sections.CompoundGeometry` objects created from a
+   :class:`shapely.geometry.MultiPolygon` will have its constituent
+   :class:`~sectionproperties.pre.sections.Geometry` objects assigned the default material.
 
 
 Defining Material Properties
 ----------------------------
 
-Materials are defined in *sectionproperties* by creating a :class:`~sectionproperties.pre.pre.Material` object:
+Materials are defined in *sectionproperties* by creating a
+:class:`~sectionproperties.pre.pre.Material` object:
 
 ..  autoclass:: sectionproperties.pre.pre.Material
     :noindex:
-    :show-inheritance:
 
 Each :class:`~sectionproperties.pre.sections.Geometry` contains its own material definition,
-which is stored in the :attr:`~sectionproperties.pre.sections.Geometry.material` attribute. A geometry's material
-may be altered at any time by simply assigning a new :class:`~sectionproperties.pre.pre.Material` to the ``.material`` attribute.
+which is stored in the ``.material`` attribute. A geometry's material may be altered at any time by
+simply assigning a new :class:`~sectionproperties.pre.pre.Material` to the ``.material`` attribute.
 
-.. note::
-   A :class:`~sectionproperties.pre.sections.CompoundGeometry` is composed of multiple :class:`~sectionproperties.pre.sections.Geometry` objects,
-   each of which have their own 
+.. warning::
+
+   To understand how material properties affect the results reported by *sectionproperties*, see
+   :ref:`label-material-results`.
+
 
 Creating Section Geometries
 ===========================
 
-In addition to creating geometries directly from `shapely.geometry.Polygon` and/or `shapely.geometry.MultiPolygon` objects
-directly, there are other ways to create geometries for analysis:
+In addition to creating geometries directly from :class:`shapely.geometry.Polygon` and/or
+:class:`shapely.geometry.MultiPolygon` objects, there are other ways to create geometries for
+analysis:
 
 #. From lists of points, facets, hole regions, and control regions
-#. From DXF files
-#. From `sectionproperties`'s "factory functions" of common shapes
-#. Using transformation methods on existing geometries and/or by applying set operations (e.g. `|`, `+`, `-`, `&`, `^`)
+#. From ``.dxf`` files
+#. From *sectionproperties*'s "factory functions" of common shapes
+#. Using transformation methods on existing geometries and/or by applying set operations
+   (e.g. `|`, `+`, `-`, `&`, `^`)
 
-For the first three approaches, an optional `materials` parameter can be passed containing a :class:`~sectionproperties.pre.pre.Material`
-(or a list of `Material` objects) to associate with the newly created geometry(ies). The material attribute can be altered afterward in a `Geometry`
-object at any time by simply assigning a different :class:`~sectionproperties.pre.pre.Material` to the `.material` attribute
+For the first three approaches, an optional ``.material`` parameter can be passed containing a
+:class:`~sectionproperties.pre.pre.Material` (or list of `Material` objects) to associate with the
+newly created geometry(ies). The material attribute can be altered afterward in a
+:class:`~sectionproperties.pre.sections.Geometry` object at any time by simply assigning a
+different :class:`~sectionproperties.pre.pre.Material` to the ``.material`` attribute.
 
 
 Geometry from points, facets, holes, and control_points
 -------------------------------------------------------
 
-In sectionproperties v1.x.x, geometries were created by specifying lists of `points`, `facets`, `holes`, and `control_points` and
-this functionality has been preserved in v2.0.0 by using `:attr:`~sectionproperties.pre.sections.Geometry.from_points()`
+In sectionproperties ``v1.x.x``, geometries were created by specifying lists of `points`, `facets`,
+`holes`, and `control_points`. This functionality has been preserved in ``v2.0.0`` by using the
+:attr:`~sectionproperties.pre.sections.Geometry.from_points()` class method.
 
-.. class:: 
-   sectionproperties.pre.sections.Geometry 
-   .. method:: from_points()
+..  autofunction:: sectionproperties.pre.sections.Geometry.from_points
    :noindex:
 
-For simple geometries (i.e. single-region shapes without holes), if the points are an ordered sequence of coordinates, only the `points` 
+For simple geometries (i.e. single-region shapes without holes), if the points are an ordered sequence of coordinates, only the `points`
 argument is required (`facets`, `holes`, and `control_points` are optional). If the geometry has holes, then all arguments are required.
 
-If the geometry has multiple regions, then `:attr:`~sectionproperties.pre.sections.CompoundGeometry.from_points()` class method must be used.
+If the geometry has multiple regions, then the
+:attr:`~sectionproperties.pre.sections.CompoundGeometry.from_points()` class method must be used.
 
-.. class:: 
-   sectionproperties.pre.sections.CompoundGeometry 
-   .. method:: from_points()
+..  autofunction:: sectionproperties.pre.sections.CompoundGeometry.from_points
    :noindex:
 
-Geometry from DXF Files
------------------------
+See :ref:`label-example-custom` for an example of this implementation.
 
-Geometries can now be created from DXF files using the :attr:`~sectionproperties.pre.sections.Geometry.from_dxf()` method. The returned geometry will either be a `Geometry`
-or `CompoundGeometry` object depending on the geometry in the file (depending on the number of contiguous regions).
 
-.. class:: 
-   sectionproperties.pre.sections.Geometry 
-   .. method:: from_dxf()
+Geometry from .dxf Files
+------------------------
+
+Geometries can now be created from ``.dxf`` files using the
+:attr:`sectionproperties.pre.sections.Geometry.from_dxf()` method. The returned geometry will
+either be a :class:`~sectionproperties.pre.sections.Geometry` or
+:class:`~sectionproperties.pre.sections.CompoundGeometry` object depending on the geometry in the
+file (i.e. the number of contiguous regions).
+
+..  autofunction:: sectionproperties.pre.sections.Geometry.from_dxf
    :noindex:
 
-.. class:: 
-   sectionproperties.pre.sections.CompoundGeometry 
-   .. method:: from_dxf()
+..  autofunction:: sectionproperties.pre.sections.CompoundGeometry.from_dxf
    :noindex:
 
-Creating Common Structural Geometries from sectionproperties "factory functions"
---------------------------------------------------------------------------------
+
+Creating Common Structural Geometries
+-------------------------------------
 
 In order to make your life easier, there are a number of built-in functions that generate typical
-structural cross-sections that create :class:`~sectionproperties.pre.sections.Geometry` objects.
+structural cross-sections, resulting in :class:`~sectionproperties.pre.sections.Geometry` objects.
 
 
 Rectangular Section
@@ -203,67 +233,93 @@ Polygon Hollow Section
 Box Girder Section
 ^^^^^^^^^^^^^^^^^^
   ..  autofunction:: sectionproperties.pre.sections.box_girder_section
-      :noindex:  
+      :noindex:
 
-Combining Geometries using set operations `+`, `-`, `|`, `^`, `&`
------------------------------------------------------------------
+
+Combining Geometries Using Set Operations
+-----------------------------------------
 
 Both `Geometry` and `CompoundGeometry` objects can be manipulated using Python's set operators:
-- `|`  Bitwise OR - Performs a union on the two geometries
-- `-`  Bitwise DIFFERENCE - Performs a subtraction, subtracting the second geometry from the first
-- `&`  Bitwise AND - Performs an intersection operation, returning the regions of geometry common to both
-- `^`  Bitwise XOR - Performs a symmetric difference operation, returning the regions of geometry that are not overlapping
-- `+`  Addition - Combines two geometries into a `CompoundGeometry`
+
+- ``|``  Bitwise OR - Performs a union on the two geometries
+- ``-``  Bitwise DIFFERENCE - Performs a subtraction, subtracting the second geometry from the
+  first
+- ``&``  Bitwise AND - Performs an intersection operation, returning the regions of geometry common
+  to both
+- ``^``  Bitwise XOR - Performs a symmetric difference operation, returning the regions of geometry
+  that are not overlapping
+- ``+``  Addition - Combines two geometries into a `CompoundGeometry`
+
+See :ref:`label-advanced_geom` for an example using set operations.
+
 
 Manipulating Geometries
 =======================
 
 Each geometry instance is able to be manipulated in 2D space for the purpose of creating novel, custom section geometries
-that the user may require. 
+that the user may require.
 
-.. note::   
-   Operations on geometries are _non-destructive_. For each operation, a new geometry object is returned.
+.. note::
+   Operations on geometries are **non-destructive**. For each operation, a new geometry object is
+   returned.
 
-   This gives sectionproperties geoemtries a *fluent API* meaning that transformation methods can be
-   chained together. Please see :doc:`./advanced_geom` for examples.
+   This gives *sectionproperties* geoemtries a *fluent API* meaning that transformation methods can
+   be chained together. Please see :ref:`label-advanced_geom` for examples.
 
-Shifting, Aligning, Mirroring, Rotating, etc.
----------------------------------------------
 
-  .. automethod:: sectionproperties.pre.sections.Geometry.align_center
-     :noindex:
+Aligning
+--------
 
-  .. automethod:: sectionproperties.pre.sections.Geometry.align_to
-     :noindex:
-   
-  .. automethod:: sectionproperties.pre.sections.Geometry.mirror_section
-     :noindex:
+  ..  autofunction:: sectionproperties.pre.sections.Geometry.align_center
+      :noindex:
 
-  .. automethod:: sectionproperties.pre.sections.Geometry.offset_perimeter
-     :noindex:
+  ..  autofunction:: sectionproperties.pre.sections.Geometry.align_to
+      :noindex:
 
-  .. automethod:: sectionproperties.pre.sections.Geometry.rotate_section
-     :noindex:
- 
-  .. automethod:: sectionproperties.pre.sections.Geometry.shift_points
-     :noindex:
+Mirroring
+---------
 
-  .. automethod:: sectionproperties.pre.sections.Geometry.shift_section
-     :noindex:
+  ..  autofunction:: sectionproperties.pre.sections.Geometry.mirror_section
+      :noindex:
 
-  .. automethod:: sectionproperties.pre.sections.Geometry.split_section
-     :noindex:
+Rotating
+--------
 
-Visualising the Geometry
+  ..  autofunction:: sectionproperties.pre.sections.Geometry.rotate_section
+      :noindex:
+
+Shifting
+--------
+
+  ..  autofunction:: sectionproperties.pre.sections.Geometry.shift_points
+      :noindex:
+
+  ..  autofunction:: sectionproperties.pre.sections.Geometry.shift_section
+      :noindex:
+
+Splitting
+---------
+
+  ..  autofunction:: sectionproperties.pre.sections.Geometry.split_section
+      :noindex:
+
+Offsetting the Perimeter
 ------------------------
 
-Visualization of geometry objects is best performed in the Jupyter computing environment,
-however, most visualization can also be done in any environment which supports display of
+  ..  autofunction:: sectionproperties.pre.sections.Geometry.offset_perimeter
+      :noindex:
+
+
+Visualising the Geometry
+========================
+
+Visualisation of geometry objects is best performed in the Jupyter computing environment,
+however, most visualisation can also be done in any environment which supports display of
 matplotlib plots.
 
-There are generally two ways to visualize geometry objects:
+There are generally two ways to visualise geometry objects:
 
-#. In the Jupyter computing environment, geometry objects utilize their underlying
+#. In the Jupyter computing environment, geometry objects utilise their underlying
    ``shapely.geometry.Polygon`` object's ``_repr_svg_`` method to show the geometry
    as it's own representation.
 #. By using the :attr:`~sectionproperties.pre.sections.Geometry.plot_geometry()` method
@@ -274,11 +330,12 @@ There are generally two ways to visualize geometry objects:
 .. note::
    You can also use ``.plot_geometry()`` with ``CompoundGeometry`` objects
 
-Generating a Mesh
------------------
 
-A finite element mesh is required to perform a cross-section analysis. After a geometry has been created,
-a finite element mesh can then be created for the geometry by using the 
+Generating a Mesh
+=================
+
+A finite element mesh is required to perform a cross-section analysis. After a geometry has been
+created, a finite element mesh can then be created for the geometry by using the
 :attr:`~sectionproperties.pre.sections.Geometry.create_mesh()` method:
 
 ..  automethod:: sectionproperties.pre.sections.Geometry.create_mesh
@@ -290,4 +347,4 @@ a finite element mesh can then be created for the geometry by using the
 Once the mesh has been created, it is stored within the geometry object and the geometry object
 can then be passed to :class:`~sectionproperties.analysis.cross_section.Section` for analysis.
 
-Please see :doc:`./analysis` for further information on performing analyses.
+Please see :ref:`label-analysis` for further information on performing analyses.

--- a/docs/source/rst/post.rst
+++ b/docs/source/rst/post.rst
@@ -167,6 +167,14 @@ Shape Factors
     :noindex:
 
 
+.. _label-material-results:
+
+How Material Properties Affect Results
+--------------------------------------
+
+PLACEHOLDER
+
+
 Section Property Centroids Plots
 --------------------------------
 

--- a/docs/source/rst/structure.rst
+++ b/docs/source/rst/structure.rst
@@ -30,7 +30,7 @@ of 2.5::
       import sectionproperties.pre.sections as sections
 
       geometry = sections.circular_section(d=50, n=64)
-      geometry = geometry.create_mesh(mesh_sizes=[2.5])
+      geometry.create_mesh(mesh_sizes=[2.5])
 
 ..  figure:: ../images/sections/circle_mesh.png
     :align: center
@@ -161,8 +161,8 @@ method::
   y2_se   = 4.905074e-06
   A_sx    = 9.468851e+02
   A_sy    = 1.106943e+03
-  A_s11	  = 9.468854e+02
-  A_s22	  = 1.106943e+03
+  A_s11   = 9.468854e+02
+  A_s22   = 1.106943e+03
   betax+  = 1.671593e-05
   betax-  = -1.671593e-05
   betay+  = -2.013448e+02

--- a/sectionproperties/pre/sections.py
+++ b/sectionproperties/pre/sections.py
@@ -648,13 +648,17 @@ class Geometry:
         :rtype: :class:`sections.pre.sections.Geometry`
 
         The following example expands the sides of a rectangle, one point at a time,
-        to make it a square.
+        to make it a square::
 
             import sectionproperties.pre.sections as sections
 
             geometry = sections.rectangular_section(d=200, b=150)
-            one_pt_shifted_geom = geometry.shift_points(point_idxs=1, dx=50) # Using relative shifting
-            both_pts_shift_geom = one_pt_shift_geom.shift_points(point_idxs=2, abs_x=200) # Using absolute relocation
+
+            # Using relative shifting
+            one_pt_shifted_geom = geometry.shift_points(point_idxs=1, dx=50)
+
+            # Using absolute relocation
+            both_pts_shift_geom = one_pt_shift_geom.shift_points(point_idxs=2, abs_x=200)
         """
         current_points = copy.copy(self.points)
         current_facets = copy.copy(self.facets)
@@ -1522,7 +1526,7 @@ def rectangular_section(b, d, material: pre.Material = pre.DEFAULT_MATERIAL) -> 
         import sectionproperties.pre.sections as sections
 
         geometry = sections.rectangular_section(d=100, b=50)
-        mesh = geometry.create_mesh(mesh_sizes=[5])
+        geometry.create_mesh(mesh_sizes=[5])
 
     ..  figure:: ../images/sections/rectangle_geometry.png
         :align: center
@@ -1555,7 +1559,7 @@ def circular_section(d: float, n: int, material: pre.Material = pre.DEFAULT_MATE
         import sectionproperties.pre.sections as sections
 
         geometry = sections.circular_section(d=50, n=64)
-        mesh = geometry.create_mesh(mesh_sizes=[2.5])
+        geometry.create_mesh(mesh_sizes=[2.5])
 
     ..  figure:: ../images/sections/circle_geometry.png
         :align: center
@@ -1654,7 +1658,7 @@ def elliptical_section(d_y: float, d_x: float, n: int, material: pre.Material = 
         import sectionproperties.pre.sections as sections
 
         geometry = sections.elliptical_section(d_y=25, d_x=50, n=40)
-        mesh = geometry.create_mesh(mesh_sizes=[1.0])
+        geometry.create_mesh(mesh_sizes=[1.0])
 
     ..  figure:: ../images/sections/ellipse_geometry.png
         :align: center
@@ -1704,7 +1708,7 @@ def elliptical_hollow_section(d_y: float, d_x: float, t: float, n: int, material
         import sectionproperties.pre.sections as sections
 
         geometry = sections.elliptical_hollow_section(d_y=25, d_x=50, t=2.0, n=64)
-        mesh = geometry.create_mesh(mesh_sizes=[0.5])
+        geometry.create_mesh(mesh_sizes=[0.5])
 
     ..  figure:: ../images/sections/ehs_geometry.png
         :align: center
@@ -1760,7 +1764,7 @@ def rectangular_hollow_section(b: float, d: float, t: float, r_out: float, n_r: 
         import sectionproperties.pre.sections as sections
 
         geometry = sections.rectangular_hollow_section(d=100, b=50, t=6, r_out=9, n_r=8)
-        mesh = geometry.create_mesh(mesh_sizes=[2.0])
+        geometry.create_mesh(mesh_sizes=[2.0])
 
     ..  figure:: ../images/sections/rhs_geometry.png
         :align: center
@@ -1816,7 +1820,7 @@ def i_section(
         import sectionproperties.pre.sections as sections
 
         geometry = sections.i_section(d=203, b=133, t_f=7.8, t_w=5.8, r=8.9, n_r=16)
-        mesh = geometry.create_mesh(mesh_sizes=[3.0])
+        geometry.create_mesh(mesh_sizes=[3.0])
 
     ..  figure:: ../images/sections/isection_geometry.png
         :align: center
@@ -1891,7 +1895,7 @@ def mono_i_section(d, b_t, b_b, t_fb, t_ft, t_w, r, n_r, material: pre.Material 
         geometry = sections.mono_i_section(
             d=200, b_t=50, b_b=130, t_ft=12, t_fb=8, t_w=6, r=8, n_r=16
         )
-        mesh = geometry.create_mesh(mesh_sizes=[3.0])
+        geometry.create_mesh(mesh_sizes=[3.0])
 
     ..  figure:: ../images/sections/monoisection_geometry.png
         :align: center
@@ -1969,7 +1973,7 @@ def tapered_flange_i_section(d, b, t_f, t_w, r_r, r_f, alpha, n_r, material: pre
         geometry = sections.tapered_flange_i_section(
             d=588, b=191, t_f=27.2, t_w=15.2, r_r=17.8, r_f=8.9, alpha=8, n_r=16
         )
-        mesh = geometry.create_mesh(mesh_sizes=[20.0])
+        geometry.create_mesh(mesh_sizes=[20.0])
 
     ..  figure:: ../images/sections/taperedisection_geometry.png
         :align: center
@@ -2157,7 +2161,7 @@ def channel_section(d, b, t_f, t_w, r, n_r, material: pre.Material = pre.DEFAULT
         import sectionproperties.pre.sections as sections
 
         geometry = sections.channel_section(d=250, b=90, t_f=15, t_w=8, r=12, n_r=8)
-        mesh = geometry.create_mesh(mesh_sizes=[5.0])
+        geometry.create_mesh(mesh_sizes=[5.0])
 
     ..  figure:: ../images/sections/pfc_geometry.png
         :align: center
@@ -2222,7 +2226,7 @@ def tapered_flange_channel(d, b, t_f, t_w, r_r, r_f, alpha, n_r, material: pre.M
         geometry = sections.tapered_flange_channel(
             d=10, b=3.5, t_f=0.575, t_w=0.475, r_r=0.575, r_f=0.4, alpha=8, n_r=16
         )
-        mesh = geometry.create_mesh(mesh_sizes=[0.02])
+        geometry.create_mesh(mesh_sizes=[0.02])
 
     ..  figure:: ../images/sections/taperedchannel_geometry.png
         :align: center
@@ -2344,7 +2348,7 @@ def tee_section(d, b, t_f, t_w, r, n_r, material: pre.Material = pre.DEFAULT_MAT
         import sectionproperties.pre.sections as sections
 
         geometry = sections.tee_section(d=200, b=100, t_f=12, t_w=6, r=8, n_r=8)
-        mesh = geometry.create_mesh(mesh_sizes=[3.0])
+        geometry.create_mesh(mesh_sizes=[3.0])
 
     ..  figure:: ../images/sections/tee_geometry.png
         :align: center
@@ -2401,7 +2405,7 @@ def angle_section(d, b, t, r_r, r_t, n_r, material: pre.Material = pre.DEFAULT_M
         import sectionproperties.pre.sections as sections
 
         geometry = sections.angle_section(d=150, b=100, t=8, r_r=12, r_t=5, n_r=16)
-        mesh = geometry.create_mesh(mesh_sizes=[2.0])
+        geometry.create_mesh(mesh_sizes=[2.0])
 
     ..  figure:: ../images/sections/angle_geometry.png
         :align: center
@@ -2465,7 +2469,7 @@ def cee_section(d, b, l, t, r_out, n_r, material: pre.Material = pre.DEFAULT_MAT
         import sectionproperties.pre.sections as sections
 
         geometry = sections.cee_section(d=125, b=50, l=30, t=1.5, r_out=6, n_r=8)
-        mesh = geometry.create_mesh(mesh_sizes=[0.25])
+        geometry.create_mesh(mesh_sizes=[0.25])
 
     ..  figure:: ../images/sections/cee_geometry.png
         :align: center
@@ -2546,7 +2550,7 @@ def zed_section(d, b_l, b_r, l, t, r_out, n_r, material: pre.Material = pre.DEFA
         import sectionproperties.pre.sections as sections
 
         geometry = sections.zed_section(d=100, b_l=40, b_r=50, l=20, t=1.2, r_out=5, n_r=8)
-        mesh = geometry.create_mesh(mesh_sizes=[0.15])
+        geometry.create_mesh(mesh_sizes=[0.15])
 
     ..  figure:: ../images/sections/zed_geometry.png
         :align: center
@@ -2624,7 +2628,7 @@ def cruciform_section(d, b, t, r, n_r, material: pre.Material = pre.DEFAULT_MATE
         import sectionproperties.pre.sections as sections
 
         geometry = sections.cruciform_section(d=250, b=175, t=12, r=16, n_r=16)
-        mesh = geometry.create_mesh(mesh_sizes=[5.0])
+        geometry.create_mesh(mesh_sizes=[5.0])
 
     ..  figure:: ../images/sections/cruciform_geometry.png
         :align: center
@@ -2699,7 +2703,7 @@ def polygon_hollow_section(d, t, n_sides, r_in=0, n_r=1, rot=0, material: pre.Ma
         import sectionproperties.pre.sections as sections
 
         geometry = sections.polygon_hollow_section(d=200, t=6, n_sides=8, r_in=20, n_r=12)
-        mesh = geometry.create_mesh(mesh_sizes=[5])
+        geometry.create_mesh(mesh_sizes=[5])
 
     ..  figure:: ../images/sections/polygon_geometry.png
         :align: center
@@ -2832,7 +2836,7 @@ def box_girder_section(d, b_t, b_b, t_ft, t_fb, t_w, material: pre.Material = pr
         import sectionproperties.pre.sections as sections
 
         geometry = sections.box_girder_section(d=1200, b_t=1200, b_b=400, t_ft=100, t_fb=80, t_w=50)
-        mesh = geometry.create_mesh(mesh_sizes=[200.0])
+        geometry.create_mesh(mesh_sizes=[200.0])
 
     ..  figure:: ../images/sections/box_girder_geometry.png
         :align: center


### PR DESCRIPTION
Few changes here relating to the Creating Geometries, Meshes, and Material Properties page.

In summary:
- Various fixes to ensure the readthedocs build renders correctly.
- Various editing with minor restructuing to improve readability
- Creating a placeholder for explaining how material properties affect results to address #53

Most importantly, removing US z's in visualisation.