### PR TITLE
Fix: control point rotation

### DIFF
--- a/sectionproperties/pre/sections.py
+++ b/sectionproperties/pre/sections.py
@@ -10,6 +10,7 @@ from shapely.geometry import (
     MultiPolygon,
     LinearRing,
     Point,
+    box,
 )
 from shapely.ops import split, unary_union
 import shapely
@@ -427,7 +428,7 @@ class Geometry:
         if self.assigned_control_point:
             rotate_point = rot_point
             if rot_point == "center":
-                rotate_point = self.geom.centroid
+                rotate_point = box(*self.geom.bounds).centroid
             new_ctrl_point = shapely.affinity.rotate(
                 self.assigned_control_point, angle, rotate_point, use_radians
                 ).coords[0]


### PR DESCRIPTION
Generate the section bounding box and find its centroid. This matches the definition of 'center' in shapely.affinity.rotate. 

Resolves: #99 