### PR TITLE
Vector plot fix

### DIFF
--- a/sectionproperties/analysis/cross_section.py
+++ b/sectionproperties/analysis/cross_section.py
@@ -2408,7 +2408,7 @@ class StressPost:
         post.setup_plot(ax, pause)
 
         # plot the finite element mesh
-        self.cross_section.plot_mesh(ax, pause, alpha=0.5)
+        self.cross_section.plot_mesh(ax, pause, materials=False, alpha=0.5)
 
         # set up the colormap
         cmap = cm.get_cmap(name=cmap)


### PR DESCRIPTION
Stop material labels from displaying over stress scale for vector plots