### PR TITLE
Implement calculation of cross-section mass

### DIFF
--- a/docs/source/rst/advanced_geom.rst
+++ b/docs/source/rst/advanced_geom.rst
@@ -42,8 +42,8 @@ Assign a unique material to each geometry::
 
     from sectionproperties.pre.pre import Material
 
-    mat1 = Material("Material_1", 200e3, 0.3, 400, "red")
-    mat2 = Material("Material_2", 150e3, 0.2, 200, "blue")  # Just some differing properties
+    mat1 = Material("Material_1", 200e3, 0.3, 100, 400, "red")
+    mat2 = Material("Material_2", 150e3, 0.2, 100, 200, "blue")  # Just some differing properties
 
     i_sec1.material = mat1
     i_sec2.material = mat2
@@ -172,10 +172,10 @@ Here, we will simply combine two squares with the default material::
     :scale: 100 %
 
 From the shapely vector representation, we can see that the squares are shaded red.
-This indicates an `"invalid" geometry from shapely's perspective <https://shapely.readthedocs.io/en/stable/manual.html#polygons>`_ 
+This indicates an `"invalid" geometry from shapely's perspective <https://shapely.readthedocs.io/en/stable/manual.html#polygons>`_
 because there are two polygons that share an edge. For this geometry, the intention is to have two squares
 that are connected on one side and so the red shading provided by the shapely representation tells us that
-we are getting what we expect. 
+we are getting what we expect.
 
 Now, say this is not our final geometry and we actually want to have it rotated by 30 degrees::
 
@@ -183,7 +183,7 @@ Now, say this is not our final geometry and we actually want to have it rotated 
 
 ..  figure:: ../images/examples/two_squares_basic_rotated.png
     :align: center
-    :scale: 100 %  
+    :scale: 100 %
 
 Here, we can see that the shapely representation is now showing as green indicating a "valid" shapely geometry.
 Even though it is now valid for shapely, because it is green we know that these two polygons no longer share an edge
@@ -204,11 +204,11 @@ do not perfectly align, they will be considered as discontinuous.
 
 ..  figure:: ../images/examples/two_squares_basic_rotated_plot.png
     :align: center
-    :scale: 100 %  
+    :scale: 100 %
 
 To remedy this, take the same approach as in the preceding example by creating intermediate nodes where the two polygons
 intersect by using set operations. If we subtract ``s2`` from ``s1`` then we will have the larger square with intermediate nodes created::
-    
+
     (s1 - s2).plot_geometry(labels=['points'])
 
 .. figure:: ../images/examples/two_squares_large_square_int_points.png

--- a/docs/source/rst/examples.rst
+++ b/docs/source/rst/examples.rst
@@ -717,9 +717,9 @@ to the terminal and a plot of the centroids and cross-section stresses generated
   from sectionproperties.analysis.cross_section import Section
 
   # create material properties
-  steel = Material(name='Steel', elastic_modulus=200e3, poissons_ratio=0.3,
+  steel = Material(name='Steel', elastic_modulus=200e3, poissons_ratio=0.3, density=7.85e-6,
                    yield_strength=500, color='grey')
-  timber = Material(name='Timber', elastic_modulus=8e3, poissons_ratio=0.35,
+  timber = Material(name='Timber', elastic_modulus=8e3, poissons_ratio=0.35, density=6.5e-7,
                     yield_strength=20, color='burlywood')
 
   # create 310UB40.4

--- a/docs/source/rst/post.rst
+++ b/docs/source/rst/post.rst
@@ -37,6 +37,12 @@ Section Perimeter
 ..  automethod:: sectionproperties.analysis.cross_section.Section.get_perimeter
     :noindex:
 
+Section Mass
+^^^^^^^^^^^^
+
+..  automethod:: sectionproperties.analysis.cross_section.Section.get_mass
+    :noindex:
+
 Axial Rigidity
 ^^^^^^^^^^^^^^
 

--- a/docs/source/rst/structure.rst
+++ b/docs/source/rst/structure.rst
@@ -44,8 +44,8 @@ class. The following example creates a steel material object::
 
       from sectionproperties.pre.pre import Material
 
-      steel = Material(name='Steel', elastic_modulus=200e3, poissons_ratio=0.3, yield_strength=500,
-                       color='grey')
+      steel = Material(name='Steel', elastic_modulus=200e3, poissons_ratio=0.3, density=7.85e-6,
+                       yield_strength=500, color='grey')
 
 Refer to :ref:`label-geom_mesh` for a more detailed explanation of the pre-processing
 stage.
@@ -76,8 +76,8 @@ property::
   from sectionproperties.pre.pre import Material
 
 
-  steel = Material(name='Steel', elastic_modulus=200e3, poissons_ratio=0.3, yield_strength=500,
-                   color='grey')
+  steel = Material(name='Steel', elastic_modulus=200e3, poissons_ratio=0.3, density=7.85e-6,
+                   yield_strength=500, color='grey')
   geometry = sections.circular_section(d=50, n=64, material=steel)
   geometry.create_mesh(mesh_sizes=[2.5])  # Adds the mesh to the geometry
 

--- a/sectionproperties/analysis/cross_section.py
+++ b/sectionproperties/analysis/cross_section.py
@@ -197,6 +197,7 @@ class Section:
 
         * Cross-sectional area
         * Cross-sectional perimeter
+        * Cross-sectional mass
         * Modulus weighted area (axial rigidity)
         * First moments of area
         * Second moments of area about the global axis
@@ -220,6 +221,7 @@ class Section:
             # initialise properties
             self.section_props.area = 0
             self.section_props.perimeter = 0
+            self.section_props.mass = 0
             self.section_props.ea = 0
             self.section_props.ga = 0
             self.section_props.qx = 0
@@ -233,8 +235,9 @@ class Section:
 
             # calculate global geometric properties
             for el in self.elements:
-                (area, qx, qy, ixx_g, iyy_g, ixy_g, e, g) = el.geometric_properties()
+                (area, qx, qy, ixx_g, iyy_g, ixy_g, e, g, rho) = el.geometric_properties()
                 self.section_props.area += area
+                self.section_props.mass += area * rho
                 self.section_props.ea += area * e
                 self.section_props.ga += area * g
                 self.section_props.qx += qx * e
@@ -687,7 +690,7 @@ class Section:
 
             # calculate global geometric properties
             for el in self.elements:
-                (area, qx, qy, ixx_g, iyy_g, ixy_g, e, _) = el.geometric_properties()
+                (area, qx, qy, ixx_g, iyy_g, ixy_g, e, _, _) = el.geometric_properties()
 
                 self.section_props.area += area
                 self.section_props.ea += area * e
@@ -1080,12 +1083,12 @@ class Section:
             from sectionproperties.analysis.cross_section import Section
 
             steel = Material(
-                name='Steel', elastic_modulus=200e3, poissons_ratio=0.3, yield_strength=250,
-                color='grey'
+                name='Steel', elastic_modulus=200e3, poissons_ratio=0.3, density=7.85e-6,
+                yield_strength=250, color='grey'
             )
             timber = Material(
-                name='Timber', elastic_modulus=8e3, poissons_ratio=0.35, yield_strength=20,
-                color='burlywood'
+                name='Timber', elastic_modulus=8e3, poissons_ratio=0.35, density=6.5e-7,
+                yield_strength=20, color='burlywood'
             )
 
             geom_steel = sections.rectangular_section(d=50, b=50, material=steel)
@@ -1370,6 +1373,20 @@ class Section:
         """
 
         return self.section_props.perimeter
+
+    def get_mass(self):
+        """
+        :return: Cross-section mass
+        :rtype: float
+
+        ::
+
+            section = Section(geometry)
+            section.calculate_geometric_properties()
+            perimeter = section.get_mass()
+        """
+
+        return self.section_props.mass
 
     def get_ea(self):
         """
@@ -2539,12 +2556,12 @@ class StressPost:
             from sectionproperties.analysis.cross_section import Section
 
             steel = Material(
-                name='Steel', elastic_modulus=200e3, poissons_ratio=0.3, yield_strength=250,
-                color='grey'
+                name='Steel', elastic_modulus=200e3, poissons_ratio=0.3, density=7.85e-6,
+                yield_strength=250, color='grey'
             )
             timber = Material(
-                name='Timber', elastic_modulus=8e3, poissons_ratio=0.35, yield_strength=20,
-                color='burlywood'
+                name='Timber', elastic_modulus=8e3, poissons_ratio=0.35, density=6.5e-7,
+                yield_strength=20, color='burlywood'
             )
 
             geom_steel = sections.rectangular_section(d=50, b=50, material=steel)
@@ -4375,6 +4392,7 @@ class SectionProperties:
 
     :cvar float area: Cross-sectional area
     :cvar float perimeter: Cross-sectional perimeter
+    :cvar float mass: Cross-sectional mass
     :cvar float ea: Modulus weighted area (axial rigidity)
     :cvar float ga: Modulus weighted product of shear modulus and area
     :cvar float nu_eff: Effective Poisson's ratio
@@ -4475,6 +4493,7 @@ class SectionProperties:
 
     area: Optional[float] = None
     perimeter: Optional[float] = None
+    mass: Optional[float] = None
     ea: Optional[float] = None
     ga: Optional[float] = None
     nu_eff: Optional[float] = None

--- a/sectionproperties/analysis/fea.py
+++ b/sectionproperties/analysis/fea.py
@@ -45,7 +45,7 @@ class Tri6:
         """Calculates the geometric properties for the current finite element.
 
         :return: Tuple containing the geometric properties and the elastic and shear moduli of the
-            element: *(area, qx, qy, ixx, iyy, ixy, e, g)*
+            element: *(area, qx, qy, ixx, iyy, ixy, e, g, rho)*
         :rtype: tuple(float)
         """
 
@@ -88,6 +88,7 @@ class Tri6:
             ixy,
             self.material.elastic_modulus,
             self.material.shear_modulus,
+            self.material.density
         )
 
     def torsion_properties(self):

--- a/sectionproperties/post/post.py
+++ b/sectionproperties/post/post.py
@@ -130,6 +130,11 @@ def print_results(cross_section, fmt):
         print("Perim.\t = {:>{fmt}}".format(perimeter, fmt=fmt))
 
     if list(set(cross_section.materials)) != [DEFAULT_MATERIAL]:
+        mass = cross_section.get_mass()
+        if mass is not None:
+            print("Mass\t = {:>{fmt}}".format(mass, fmt=fmt))
+
+    if list(set(cross_section.materials)) != [DEFAULT_MATERIAL]:
         ea = cross_section.get_ea()
         if ea is not None:
             print("E.A\t = {:>{fmt}}".format(ea, fmt=fmt))

--- a/sectionproperties/pre/pre.py
+++ b/sectionproperties/pre/pre.py
@@ -23,6 +23,7 @@ class Material:
     :param float elastic_modulus: Material modulus of elasticity
     :param float poissons_ratio: Material Poisson's ratio
     :param float yield_strength: Material yield strength
+    :param float density: Material density (mass per unit volume)
     :param color: Material color for rendering
     :type color: :class:`matplotlib.colors`
 
@@ -31,6 +32,7 @@ class Material:
     :cvar float poissons_ratio: Material Poisson's ratio
     :cvar float shear_modulus: Material shear modulus, derived from the elastic modulus and
         Poisson's ratio assuming an isotropic material
+    :cvar float density: Material density (mass per unit volume)
     :cvar float yield_strength: Material yield strength
     :cvar color: Material color for rendering
     :vartype color: :class:`matplotlib.colors`
@@ -40,16 +42,16 @@ class Material:
         from sectionproperties.pre.pre import Material
 
         concrete = Material(
-            name='Concrete', elastic_modulus=30.1e3, poissons_ratio=0.2, yield_strength=32,
-                color='lightgrey'
+            name='Concrete', elastic_modulus=30.1e3, poissons_ratio=0.2, density=2.4e-6,
+                yield_strength=32, color='lightgrey'
         )
         steel = Material(
-            name='Steel', elastic_modulus=200e3, poissons_ratio=0.3, yield_strength=500,
-                color='grey'
+            name='Steel', elastic_modulus=200e3, poissons_ratio=0.3, density=7.85e-6,
+                yield_strength=500, color='grey'
         )
         timber = Material(
-            name='Timber', elastic_modulus=8e3, poissons_ratio=0.35, yield_strength=20,
-                color='burlywood'
+            name='Timber', elastic_modulus=8e3, poissons_ratio=0.35, density=6.5e-7,
+                yield_strength=20, color='burlywood'
         )
     """
 
@@ -57,6 +59,7 @@ class Material:
     elastic_modulus: float
     poissons_ratio: float
     yield_strength: float
+    density: float
     color: str
 
     @property
@@ -64,7 +67,7 @@ class Material:
         return self.elastic_modulus / (2 * (1 + self.poissons_ratio))
 
 
-DEFAULT_MATERIAL = Material("default", 1, 0, 1, "w")
+DEFAULT_MATERIAL = Material("default", 1, 0, 1, 1, "w")
 
 
 def create_mesh(

--- a/sectionproperties/tests/test_rectangle.py
+++ b/sectionproperties/tests/test_rectangle.py
@@ -25,6 +25,7 @@ def test_rectangular_section_geometric():
     check.almost_equal(
         rectangle_section.section_props.perimeter, 2 * 100 + 2 * 50, rel=tol
     )
+    check.almost_equal(rectangle_section.section_props.mass, 1 * 100 * 50, rel=tol)
     check.almost_equal(rectangle_section.section_props.ea, 1 * 100 * 50, rel=tol)
     check.almost_equal(rectangle_section.section_props.qx, 100 * 50 * 50, rel=tol)
     check.almost_equal(rectangle_section.section_props.qy, 100 * 50 * 25, rel=tol)

--- a/sectionproperties/tests/test_sections.py
+++ b/sectionproperties/tests/test_sections.py
@@ -33,7 +33,7 @@ def test_material_persistence():
     # returns a new Geometry object.
     # The material assignment should persist through all of the
     # transformations
-    steel = Material("steel", 200e3, 0.3, 400, "grey")
+    steel = Material("steel", 200e3, 0.3, 7.85e-6, 400, "grey")
     big_sq.material = steel
     new_geom = (
         big_sq.align_to(small_sq, on="left", inner=False)
@@ -145,13 +145,13 @@ def test_geometry_from_dxf():
 def test_plastic_centroid():
     ## Test created in response to #114
     # Since the section being tested is a compound geometry with two different
-    # materials, this tests that the plastic centroid takes into account the 
+    # materials, this tests that the plastic centroid takes into account the
     # correct "center" of the original section which is affected by EA of each
     # of the constituent geometries.
 
-    steel = Material(name='Steel', elastic_modulus=200e3, poissons_ratio=0.3,
+    steel = Material(name='Steel', elastic_modulus=200e3, poissons_ratio=0.3, density=7.85e-6,
                     yield_strength=500, color='grey')
-    timber = Material(name='Timber', elastic_modulus=5e3, poissons_ratio=0.35,
+    timber = Material(name='Timber', elastic_modulus=5e3, poissons_ratio=0.35, density=6.5e-7,
                     yield_strength=20, color='burlywood')
 
     # create 310UB40.4
@@ -172,7 +172,6 @@ def test_plastic_centroid():
 
     # perform a geometric, warping and plastic analysis
     section.calculate_geometric_properties()
-    section.calculate_warping_properties()
     section.calculate_plastic_properties()
 
     x_pc, y_pc = section.get_pc()
@@ -225,4 +224,4 @@ def test_geometry_from_3dm_encode():
         brep_encoded = json.load(file)
     exp = Polygon([(0,0), (1,0), (1,1), (0,1), (0,0)])
     test = Geometry.from_rhino_encoding(brep_encoded)
-    assert (test.geom-exp).is_empty 
+    assert (test.geom-exp).is_empty


### PR DESCRIPTION
Summary of changes:

- Material properties now require `density` variable
- `calculate_geometric_properties()` now calculates cross-section mass
- Added `get_mass()` method to `Section` class
- `display_results()` reports mass for composite cross-sections
- Updated documentation to suit new methods
- Updated documentation where materials are mentioned to include the `density` variable
- Updated tests

See #128.