### PR TITLE
Update concrete section definitions

### DIFF
--- a/sectionproperties/pre/library/concrete_sections.py
+++ b/sectionproperties/pre/library/concrete_sections.py
@@ -8,36 +8,46 @@ import sectionproperties.pre.library.primitive_sections as primitive_sections
 def concrete_rectangular_section(
     b: float,
     d: float,
-    dia: float,
-    n_bar: int,
+    dia_top: float,
+    n_top: int,
+    dia_bot: float,
+    n_bot: int,
     n_circle: int,
     cover: float,
-    area: float = None,
+    area_top: float = None,
+    area_bot: float = None,
     conc_mat: pre.Material = pre.DEFAULT_MATERIAL,
     steel_mat: pre.Material = pre.DEFAULT_MATERIAL,
 ) -> geometry.CompoundGeometry:
-    """Constructs a concrete rectangular section of width *b* and depth *d*, with *n_bar* steel bars
-    of diameter *dia*, discretised with *n_circle* points with equal side and bottom *cover* to the
-    steel.
+    """Constructs a concrete rectangular section of width *b* and depth *d*, with
+    *n_top* top steel bars of diameter *dia_top*, *n_bot* bottom steel bars of diameter
+    *dia_bot*, discretised with *n_circle* points with equal side and top/bottom
+    *cover* to the steel.
 
     :param float b: Concrete section width
     :param float d: Concrete section depth
-    :param float dia: Diameter of the steel reinforcing bars
-    :param int n_bar: Number of steel reinforcing bars
+    :param float dia_top: Diameter of the top steel reinforcing bars
+    :param int n_top: Number of top steel reinforcing bars
+    :param float dia_bot: Diameter of the bottom steel reinforcing bars
+    :param int n_bot: Number of bottom steel reinforcing bars
     :param int n_circle: Number of points discretising the steel reinforcing bars
     :param float cover: Side and bottom cover to the steel reinforcing bars
-    :param float area: If provided, constructs reinforcing bars based on their area
-        rather than a diameter (prevents the underestimation of steel area due to
+     :param float area_top: If provided, constructs top reinforcing bars based on their
+        area rather than diameter (prevents the underestimation of steel area due to
         circle discretisation)
-    :param Optional[sectionproperties.pre.pre.Material] conc_mat: Material to associate with
-        the concrete
-    :param Optional[sectionproperties.pre.pre.Material] steel_mat: Material to associate with
-        the steel
+    :param float area_bot: If provided, constructs bottom reinforcing bars based on
+        their area rather than diameter (prevents the underestimation of steel area due
+        to circle discretisation)
+    :param Optional[sectionproperties.pre.pre.Material] conc_mat: Material to
+        associate with the concrete
+    :param Optional[sectionproperties.pre.pre.Material] steel_mat: Material to
+        associate with the steel
 
-    :raises ValueErorr: If the number of bars is not greater than or equal to 2
+    :raises ValueErorr: If the number of bars is not greater than or equal to 2 in an
+        active layer
 
-    The following example creates a 600D x 300W concrete beam with 3N20 steel reinforcing bars and
-    30 mm cover::
+    The following example creates a 600D x 300W concrete beam with 3N20 bottom steel
+    reinforcing bars and 30 mm cover::
 
         from sectionproperties.pre.library.concrete_sections import concrete_rectangular_section
         from sectionproperties.pre.pre import Material
@@ -52,7 +62,8 @@ def concrete_rectangular_section(
         )
 
         geometry = concrete_rectangular_section(
-            b=300, d=600, dia=20, n_bar=3, n_circle=24, cover=30, conc_mat=concrete, steel_mat=steel
+            b=300, d=600, dia_top=20, n_top=0, dia_bot=20, n_bot=3, n_circle=24, cover=30,
+            conc_mat=concrete, steel_mat=steel
         )
         geometry.create_mesh(mesh_sizes=[500])
 
@@ -69,25 +80,51 @@ def concrete_rectangular_section(
         Mesh generated from the above geometry.
     """
 
-    if n_bar < 2:
-        raise ValueError("Please provide 2 or more steel reinforcing bars.")
+    if n_top == 1 or n_bot == 1:
+        raise ValueError("If adding a reinforcing layer, provide 2 or more bars.")
 
+    # create rectangular concrete geometry
     geom = primitive_sections.rectangular_section(b=b, d=d, material=conc_mat)
 
-    x_i = cover + dia / 2
-    spacing = (b - 2 * cover - dia) / (n_bar - 1)
+    # calculate reinforcing bar dimensions
+    x_i_top = cover + dia_top / 2
+    x_i_bot = cover + dia_bot / 2
+    spacing_top = (b - 2 * cover - dia_top) / (n_top - 1)
+    spacing_bot = (b - 2 * cover - dia_bot) / (n_bot - 1)
 
-    for i in range(n_bar):
-        if area:
+    # add top bars
+    for i in range(n_top):
+        if area_top:
             bar = primitive_sections.circular_section_by_area(
-                area=area, n=n_circle, material=steel_mat
+                area=area_top, n=n_circle, material=steel_mat
             )
         else:
             bar = primitive_sections.circular_section(
-                d=dia, n=n_circle, material=steel_mat
+                d=dia_top, n=n_circle, material=steel_mat
             )
 
-        geom += bar.shift_section(x_offset=x_i + spacing * i, y_offset=cover + dia / 2)
+        bar = bar.shift_section(
+            x_offset=x_i_top + spacing_top * i, y_offset=d - cover - dia_top / 2
+        )
+
+        geom = (geom - bar) + bar
+
+    # add bot bars
+    for i in range(n_bot):
+        if area_bot:
+            bar = primitive_sections.circular_section_by_area(
+                area=area_bot, n=n_circle, material=steel_mat
+            )
+        else:
+            bar = primitive_sections.circular_section(
+                d=dia_bot, n=n_circle, material=steel_mat
+            )
+
+        bar = bar.shift_section(
+            x_offset=x_i_bot + spacing_bot * i, y_offset=cover + dia_bot / 2
+        )
+
+        geom = (geom - bar) + bar
 
     return geom
 
@@ -97,38 +134,48 @@ def concrete_tee_section(
     d: float,
     b_f: float,
     d_f: float,
-    dia: float,
-    n_bar: int,
+    dia_top: float,
+    n_top: int,
+    dia_bot: float,
+    n_bot: int,
     n_circle: int,
     cover: float,
-    area: float = None,
+    area_top: float = None,
+    area_bot: float = None,
     conc_mat: pre.Material = pre.DEFAULT_MATERIAL,
     steel_mat: pre.Material = pre.DEFAULT_MATERIAL,
 ) -> geometry.CompoundGeometry:
-    """Constructs a concrete tee section of width *b*, depth *d*, flange width *b_f* and flange
-    depth *d_f* with *n_bar* steel bars of diameter *dia*, discretised with *n_circle* points with
-    equal side and bottom *cover* to the steel.
+    """Constructs a concrete tee section of width *b*, depth *d*, flange width *b_f*
+    and flange depth *d_f*, with *n_top* top steel bars of diameter *dia_top*, *n_bot*
+    bottom steel bars of diameter *dia_bot*, discretised with *n_circle* points with
+    equal side and top/bottom *cover* to the steel.
 
     :param float b: Concrete section width
     :param float d: Concrete section depth
     :param float b_f: Concrete section flange width
     :param float d_f: Concrete section flange depth
-    :param float dia: Diameter of the steel reinforcing bars
-    :param int n_bar: Number of steel reinforcing bars
+    :param float dia_top: Diameter of the top steel reinforcing bars
+    :param int n_top: Number of top steel reinforcing bars
+    :param float dia_bot: Diameter of the bottom steel reinforcing bars
+    :param int n_bot: Number of bottom steel reinforcing bars
     :param int n_circle: Number of points discretising the steel reinforcing bars
     :param float cover: Side and bottom cover to the steel reinforcing bars
-    :param float area: If provided, constructs reinforcing bars based on their area
-        rather than a diameter (prevents the underestimation of steel area due to
+    :param float area_top: If provided, constructs top reinforcing bars based on their
+        area rather than diameter (prevents the underestimation of steel area due to
         circle discretisation)
-    :param Optional[sectionproperties.pre.pre.Material] conc_mat: Material to associate with
-        the concrete
-    :param Optional[sectionproperties.pre.pre.Material] steel_mat: Material to associate with
-        the steel
+    :param float area_bot: If provided, constructs bottom reinforcing bars based on
+        their area rather than diameter (prevents the underestimation of steel area due
+        to circle discretisation)
+    :param Optional[sectionproperties.pre.pre.Material] conc_mat: Material to associate
+        with the concrete
+    :param Optional[sectionproperties.pre.pre.Material] steel_mat: Material to
+        associate with the steel
 
-    :raises ValueErorr: If the number of bars is not greater than or equal to 2
+    :raises ValueErorr: If the number of bars is not greater than or equal to 2 in an
+        active layer
 
-    The following example creates a 900D x 450W concrete beam with a 1200W x 250D flange, with 5N24
-    steel reinforcing bars and 30 mm cover::
+    The following example creates a 900D x 450W concrete beam with a 1200W x 250D
+    flange, with 5N24 steel reinforcing bars and 30 mm cover::
 
         from sectionproperties.pre.library.concrete_sections import concrete_tee_section
         from sectionproperties.pre.pre import Material
@@ -143,8 +190,8 @@ def concrete_tee_section(
         )
 
         geometry = concrete_tee_section(
-            b=450, d=900, b_f=1200, d_f=250, dia=24, n_bar=5, n_circle=24, cover=30,
-            conc_mat=concrete, steel_mat=steel
+            b=450, d=900, b_f=1200, d_f=250, dia_top=24, n_top=0, dia_bot=24, n_bot=5,
+            n_circle=24, cover=30, conc_mat=concrete, steel_mat=steel
         )
         geometry.create_mesh(mesh_sizes=[500])
 
@@ -161,27 +208,53 @@ def concrete_tee_section(
         Mesh generated from the above geometry.
     """
 
-    if n_bar < 2:
-        raise ValueError("Please provide 2 or more steel reinforcing bars.")
+    if n_top == 1 or n_bot == 1:
+        raise ValueError("If adding a reinforcing layer, provide 2 or more bars.")
 
+    # generate tee-section
     geom = primitive_sections.rectangular_section(b=b, d=d - d_f, material=conc_mat)
     flange = primitive_sections.rectangular_section(b=b_f, d=d_f, material=conc_mat)
     geom += flange.align_center(align_to=geom).align_to(other=geom, on="top")
 
-    x_i = cover + dia / 2
-    spacing = (b - 2 * cover - dia) / (n_bar - 1)
+    # calculate reinforcing bar dimensions
+    x_i_top = cover + dia_top / 2 + 0.5 * (b - b_f)
+    x_i_bot = cover + dia_bot / 2
+    spacing_top = (b_f - 2 * cover - dia_top) / (n_top - 1)
+    spacing_bot = (b - 2 * cover - dia_bot) / (n_bot - 1)
 
-    for i in range(n_bar):
-        if area:
+    # add top bars
+    for i in range(n_top):
+        if area_top:
             bar = primitive_sections.circular_section_by_area(
-                area=area, n=n_circle, material=steel_mat
+                area=area_top, n=n_circle, material=steel_mat
             )
         else:
             bar = primitive_sections.circular_section(
-                d=dia, n=n_circle, material=steel_mat
+                d=dia_top, n=n_circle, material=steel_mat
             )
 
-        geom += bar.shift_section(x_offset=x_i + spacing * i, y_offset=cover + dia / 2)
+        bar = bar.shift_section(
+            x_offset=x_i_top + spacing_top * i, y_offset=d - cover - dia_top / 2
+        )
+
+        geom = (geom - bar) + bar
+
+    # add bot bars
+    for i in range(n_bot):
+        if area_bot:
+            bar = primitive_sections.circular_section_by_area(
+                area=area_bot, n=n_circle, material=steel_mat
+            )
+        else:
+            bar = primitive_sections.circular_section(
+                d=dia_bot, n=n_circle, material=steel_mat
+            )
+
+        bar = bar.shift_section(
+            x_offset=x_i_bot + spacing_bot * i, y_offset=cover + dia_bot / 2
+        )
+
+        geom = (geom - bar) + bar
 
     return geom
 
@@ -193,13 +266,14 @@ def concrete_circular_section(
     n_bar: int,
     n_circle: int,
     cover: float,
-    area: float = None,
+    area_conc: float = None,
+    area_bar: float = None,
     conc_mat: pre.Material = pre.DEFAULT_MATERIAL,
     steel_mat: pre.Material = pre.DEFAULT_MATERIAL,
 ) -> geometry.CompoundGeometry:
-    """Constructs a concrete circular section of diameter *d* discretised with *n* points, with
-    *n_bar* steel bars of diameter *dia*, discretised with *n_circle* points with equal side and
-    bottom *cover* to the steel.
+    """Constructs a concrete circular section of diameter *d* discretised with *n*
+    points, with *n_bar* steel bars of diameter *dia*, discretised with *n_circle*
+    points with equal side and bottom *cover* to the steel.
 
     :param float d: Concrete diameter
     :param float n: Number of points discretising the concrete section
@@ -207,18 +281,20 @@ def concrete_circular_section(
     :param int n_bar: Number of steel reinforcing bars
     :param int n_circle: Number of points discretising the steel reinforcing bars
     :param float cover: Side and bottom cover to the steel reinforcing bars
-    :param float area: If provided, constructs reinforcing bars based on their area
-        rather than a diameter (prevents the underestimation of steel area due to
+    :param float area_conc: If provided, constructs the concrete based on its area
+        rather than diameter (prevents the underestimation of concrete area due to
         circle discretisation)
-    :param Optional[sectionproperties.pre.pre.Material] conc_mat: Material to associate with
-        the concrete
-    :param Optional[sectionproperties.pre.pre.Material] steel_mat: Material to associate with
-        the steel
+    :param float area_bar: If provided, constructs reinforcing bars based on their area
+        rather than diameter (prevents the underestimation of steel area due to
+    :param Optional[sectionproperties.pre.pre.Material] conc_mat: Material to associate
+        with the concrete
+    :param Optional[sectionproperties.pre.pre.Material] steel_mat: Material to
+        associate with the steel
 
     :raises ValueErorr: If the number of bars is not greater than or equal to 2
 
-    The following example creates a 450DIA concrete column with with 6N20 steel reinforcing bars
-    and 45 mm cover::
+    The following example creates a 450DIA concrete column with with 6N20 steel
+    reinforcing bars and 45 mm cover::
 
         from sectionproperties.pre.library.concrete_sections import concrete_circular_section
         from sectionproperties.pre.pre import Material
@@ -253,23 +329,32 @@ def concrete_circular_section(
     if n_bar < 2:
         raise ValueError("Please provide 2 or more steel reinforcing bars.")
 
-    geom = primitive_sections.circular_section(d=d, n=n, material=conc_mat)
+    # create circular geometry
+    if area_conc:
+        geom = primitive_sections.circular_section_by_area(
+            area=area_conc, n=n, material=conc_mat
+        )
+    else:
+        geom = primitive_sections.circular_section(d=d, n=n, material=conc_mat)
 
+    # calculate bar geometry
     r = d / 2 - cover - dia / 2
     d_theta = 2 * np.pi / n_bar
 
     for i in range(n_bar):
-        if area:
+        if area_bar:
             bar = primitive_sections.circular_section_by_area(
-                area=area, n=n_circle, material=steel_mat
+                area=area_bar, n=n_circle, material=steel_mat
             )
         else:
             bar = primitive_sections.circular_section(
                 d=dia, n=n_circle, material=steel_mat
             )
 
-        geom += bar.shift_section(
+        bar = bar.shift_section(
             x_offset=r * np.cos(i * d_theta), y_offset=r * np.sin(i * d_theta)
         )
+
+        geom = (geom - bar) + bar
 
     return geom

--- a/sectionproperties/tests/test_concrete_sections.py
+++ b/sectionproperties/tests/test_concrete_sections.py
@@ -1,0 +1,137 @@
+import pytest_check as check
+import numpy as np
+import sectionproperties.pre.pre as pre
+import sectionproperties.pre.library.concrete_sections as cs
+
+r_tol = 1e-6
+conc_mat = pre.Material(
+    name="Concrete",
+    elastic_modulus=32.8e3,
+    poissons_ratio=0.2,
+    density=2.4e-6,
+    yield_strength=40,
+    color="lightgrey",
+)
+
+steel_mat = pre.Material(
+    name="Steel",
+    elastic_modulus=200e3,
+    poissons_ratio=0.3,
+    density=7.85e-6,
+    yield_strength=500,
+    color="grey",
+)
+
+
+def test_concrete_rectangular_section():
+    rect = cs.concrete_rectangular_section(
+        b=300,
+        d=600,
+        dia_top=16,
+        n_top=3,
+        dia_bot=20,
+        n_bot=3,
+        n_circle=16,
+        cover=30,
+        area_top=200,
+        area_bot=310,
+        conc_mat=conc_mat,
+        steel_mat=steel_mat,
+    )
+
+    # check geometry is created correctly
+    conc_area = 0
+    steel_area = 0
+
+    for geom in rect.geoms:
+        if geom.material == conc_mat:
+            conc_area += geom.calculate_area()
+        elif geom.material == steel_mat:
+            steel_area += geom.calculate_area()
+        else:
+            raise ValueError(
+                "Material {0} is not correctly assigned".format(geom.material)
+            )
+
+    net_area = 600 * 300
+    actual_steel_area = 3 * (200 + 310)
+
+    # check areas
+    check.almost_equal(conc_area, net_area - actual_steel_area, rel=r_tol)
+    check.almost_equal(steel_area, actual_steel_area, rel=r_tol)
+
+
+def test_concrete_tee_section():
+    rect = cs.concrete_tee_section(
+        b=300,
+        d=900,
+        b_f=1200,
+        d_f=200,
+        dia_top=20,
+        n_top=6,
+        dia_bot=24,
+        n_bot=3,
+        n_circle=16,
+        cover=30,
+        area_top=310,
+        area_bot=450,
+        conc_mat=conc_mat,
+        steel_mat=steel_mat,
+    )
+
+    # check geometry is created correctly
+    conc_area = 0
+    steel_area = 0
+
+    for geom in rect.geoms:
+        if geom.material == conc_mat:
+            conc_area += geom.calculate_area()
+        elif geom.material == steel_mat:
+            steel_area += geom.calculate_area()
+        else:
+            raise ValueError(
+                "Material {0} is not correctly assigned".format(geom.material)
+            )
+
+    net_area = 700 * 300 + 1200 * 200
+    actual_steel_area = 6 * 310 + 3 * 450
+
+    # check areas
+    check.almost_equal(conc_area, net_area - actual_steel_area, rel=r_tol)
+    check.almost_equal(steel_area, actual_steel_area, rel=r_tol)
+
+
+def test_concrete_circular_section():
+    rect = cs.concrete_circular_section(
+        d=600,
+        n=64,
+        dia=20,
+        n_bar=8,
+        n_circle=16,
+        cover=45,
+        area_conc=np.pi * 600 * 600 / 4,
+        area_bar=310,
+        conc_mat=conc_mat,
+        steel_mat=steel_mat,
+    )
+
+    # check geometry is created correctly
+    conc_area = 0
+    steel_area = 0
+
+    for geom in rect.geoms:
+        if geom.material == conc_mat:
+            conc_area += geom.calculate_area()
+        elif geom.material == steel_mat:
+            steel_area += geom.calculate_area()
+        else:
+            raise ValueError(
+                "Material {0} is not correctly assigned".format(geom.material)
+            )
+
+    net_area = np.pi * 600 * 600 / 4
+    actual_steel_area = 8 * 310
+
+    # check areas
+    check.almost_equal(conc_area, net_area - actual_steel_area, rel=r_tol)
+    check.almost_equal(steel_area, actual_steel_area, rel=r_tol)


### PR DESCRIPTION
New concrete section definitions:
- Now correctly subtracts area for reinforcement, i.e. `geom = (geom - bar) + bar`
- Added option for adding top reinforcement to rectangular and tee sections
- Added option for added circular concrete area for circular section