### PR TITLE
Fix pip install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,3 @@
-[project]
-requires-python = ">=3.7,<3.10"
-
 [build-system]
 # These are the assumed default build requirements from pip:
 # https://pip.pypa.io/en/stable/reference/pip/#pep-517-and-518-support

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ project_urls =
 packages = find:
 platforms = any
 include_package_data = True
-python_requires = >=3.7
+python_requires = >=3.7,<3.10
 setup_requires =
     setuptools
 install_requires =

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,0 @@
-import setuptools
-
-if __name__ == "__main__":
-    setuptools.setup()


### PR DESCRIPTION
Removed unnecessary data from the pyproject.toml file, which causes errors with pip install of the local repo.

Removed the setup.py file, since all metadata is statically defined in the setup.cfg.

Installing a local clone in editable mode now runs successfully.

Closes #208 