### PR TITLE
From points material fix

### DIFF
--- a/sectionproperties/analysis/section.py
+++ b/sectionproperties/analysis/section.py
@@ -1313,7 +1313,7 @@ class Section:
         :param mask: Mask array, of length ``num_nodes``, to mask out triangles
         :type mask: list[bool]
         :param string title: Plot title
-        :param \**kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
+        :param kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
 
         :return: Matplotlib axes object
         :rtype: :class:`matplotlib.axes`
@@ -1408,7 +1408,7 @@ class Section:
         axis, if they have been calculated, on top of the finite element mesh.
 
         :param string title: Plot title
-        :param \**kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
+        :param kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
 
         :return: Matplotlib axes object
         :rtype: :class:`matplotlib.axes`
@@ -2592,7 +2592,7 @@ class StressPost:
         :param string cmap: Matplotlib color map.
         :param bool normalize: If set to true, the CenteredNorm is used to scale the colormap.
             If set to false, the default linear scaling is used.
-        :param \**kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
+        :param kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
 
         :return: Matplotlib axe object
         :rtype: :class:`matplotlib.axes`
@@ -2658,7 +2658,7 @@ class StressPost:
         :param string cmap: Matplotlib color map.
         :param bool normalize: If set to true, the CenteredNorm is used to scale the colormap.
             If set to false, the default linear scaling is used.
-        :param \**kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
+        :param kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
 
         :return: Matplotlib axes object
         :rtype: :class:`matplotlib.axes`
@@ -2872,7 +2872,7 @@ class StressPost:
         :param string cmap: Matplotlib color map.
         :param bool normalize: If set to true, the CenteredNorm is used to scale the colormap.
             If set to false, the default linear scaling is used.
-        :param \**kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
+        :param kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
 
         :return: Matplotlib axes object
         :rtype: :class:`matplotlib.axes`
@@ -2921,7 +2921,7 @@ class StressPost:
         :param string cmap: Matplotlib color map.
         :param bool normalize: If set to true, the CenteredNorm is used to scale the colormap.
             If set to false, the default linear scaling is used.
-        :param \**kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
+        :param kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
 
         :return: Matplotlib axes object
         :rtype: :class:`matplotlib.axes`
@@ -2970,7 +2970,7 @@ class StressPost:
         :param string cmap: Matplotlib color map.
         :param bool normalize: If set to true, the CenteredNorm is used to scale the colormap.
             If set to false, the default linear scaling is used.
-        :param \**kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
+        :param kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
 
         :return: Matplotlib axes object
         :rtype: :class:`matplotlib.axes`
@@ -3019,7 +3019,7 @@ class StressPost:
         :param string cmap: Matplotlib color map.
         :param bool normalize: If set to true, the CenteredNorm is used to scale the colormap.
             If set to false, the default linear scaling is used.
-        :param \**kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
+        :param kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
 
         :return: Matplotlib axes object
         :rtype: :class:`matplotlib.axes`
@@ -3068,7 +3068,7 @@ class StressPost:
         :param string cmap: Matplotlib color map.
         :param bool normalize: If set to true, the CenteredNorm is used to scale the colormap.
             If set to false, the default linear scaling is used.
-        :param \**kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
+        :param kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
 
         :return: Matplotlib axes object
         :rtype: :class:`matplotlib.axes`
@@ -3117,7 +3117,7 @@ class StressPost:
         :param string cmap: Matplotlib color map.
         :param bool normalize: If set to true, the CenteredNorm is used to scale the colormap.
             If set to false, the default linear scaling is used.
-        :param \**kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
+        :param kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
 
         :return: Matplotlib axes object
         :rtype: :class:`matplotlib.axes`
@@ -3167,7 +3167,7 @@ class StressPost:
         :param string cmap: Matplotlib color map.
         :param bool normalize: If set to true, the CenteredNorm is used to scale the colormap.
             If set to false, the default linear scaling is used.
-        :param \**kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
+        :param kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
 
         :return: Matplotlib axes object
         :rtype: :class:`matplotlib.axes`
@@ -3216,7 +3216,7 @@ class StressPost:
         :param string cmap: Matplotlib color map.
         :param bool normalize: If set to true, the CenteredNorm is used to scale the colormap.
             If set to false, the default linear scaling is used.
-        :param \**kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
+        :param kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
 
         :return: Matplotlib axes object
         :rtype: :class:`matplotlib.axes`
@@ -3265,7 +3265,7 @@ class StressPost:
         :param string cmap: Matplotlib color map.
         :param bool normalize: If set to true, the CenteredNorm is used to scale the colormap.
             If set to false, the default linear scaling is used.
-        :param \**kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
+        :param kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
 
         :return: Matplotlib axes object
         :rtype: :class:`matplotlib.axes`
@@ -3314,7 +3314,7 @@ class StressPost:
         :param string cmap: Matplotlib color map.
         :param bool normalize: If set to true, the CenteredNorm is used to scale the colormap.
             If set to false, the default linear scaling is used.
-        :param \**kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
+        :param kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
 
         :return: Matplotlib axes object
         :rtype: :class:`matplotlib.axes`
@@ -3365,7 +3365,7 @@ class StressPost:
         :param string cmap: Matplotlib color map.
         :param bool normalize: If set to true, the CenteredNorm is used to scale the colormap.
             If set to false, the default linear scaling is used.
-        :param \**kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
+        :param kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
 
         :return: Matplotlib axes object
         :rtype: :class:`matplotlib.axes`
@@ -3414,7 +3414,7 @@ class StressPost:
         :param string cmap: Matplotlib color map.
         :param bool normalize: If set to true, the CenteredNorm is used to scale the colormap.
             If set to false, the default linear scaling is used.
-        :param \**kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
+        :param kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
 
         :return: Matplotlib axes object
         :rtype: :class:`matplotlib.axes`
@@ -3463,7 +3463,7 @@ class StressPost:
         :param string cmap: Matplotlib color map.
         :param bool normalize: If set to true, the CenteredNorm is used to scale the colormap.
             If set to false, the default linear scaling is used.
-        :param \**kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
+        :param kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
 
         :return: Matplotlib axes object
         :rtype: :class:`matplotlib.axes`
@@ -3513,7 +3513,7 @@ class StressPost:
         :param string cmap: Matplotlib color map.
         :param bool normalize: If set to true, the CenteredNorm is used to scale the colormap.
             If set to false, the default linear scaling is used.
-        :param \**kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
+        :param kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
 
         :return: Matplotlib axes object
         :rtype: :class:`matplotlib.axes`
@@ -3564,7 +3564,7 @@ class StressPost:
         :param string cmap: Matplotlib color map.
         :param bool normalize: If set to true, the CenteredNorm is used to scale the colormap.
             If set to false, the default linear scaling is used.
-        :param \**kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
+        :param kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
 
         :return: Matplotlib axes object
         :rtype: :class:`matplotlib.axes`
@@ -3613,7 +3613,7 @@ class StressPost:
         :param string cmap: Matplotlib color map.
         :param bool normalize: If set to true, the CenteredNorm is used to scale the colormap.
             If set to false, the default linear scaling is used.
-        :param \**kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
+        :param kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
 
         :return: Matplotlib axes object
         :rtype: :class:`matplotlib.axes`
@@ -3662,7 +3662,7 @@ class StressPost:
         :param string cmap: Matplotlib color map.
         :param bool normalize: If set to true, the CenteredNorm is used to scale the colormap.
             If set to false, the default linear scaling is used.
-        :param \**kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
+        :param kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
 
         :return: Matplotlib axes object
         :rtype: :class:`matplotlib.axes`
@@ -3711,7 +3711,7 @@ class StressPost:
         :param string cmap: Matplotlib color map.
         :param bool normalize: If set to true, the CenteredNorm is used to scale the colormap.
             If set to false, the default linear scaling is used.
-        :param \**kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
+        :param kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
 
         :return: Matplotlib axes object
         :rtype: :class:`matplotlib.axes`
@@ -3763,7 +3763,7 @@ class StressPost:
         :param string cmap: Matplotlib color map.
         :param bool normalize: If set to true, the CenteredNorm is used to scale the colormap.
             If set to false, the default linear scaling is used.
-        :param \**kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
+        :param kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
 
         :return: Matplotlib axes object
         :rtype: :class:`matplotlib.axes`
@@ -3814,7 +3814,7 @@ class StressPost:
         :param string cmap: Matplotlib color map.
         :param bool normalize: If set to true, the CenteredNorm is used to scale the colormap.
             If set to false, the default linear scaling is used.
-        :param \**kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
+        :param kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
 
         :return: Matplotlib axes object
         :rtype: :class:`matplotlib.axes`
@@ -3865,7 +3865,7 @@ class StressPost:
         :param string cmap: Matplotlib color map.
         :param bool normalize: If set to true, the CenteredNorm is used to scale the colormap.
             If set to false, the default linear scaling is used.
-        :param \**kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
+        :param kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
 
         :return: Matplotlib axes object
         :rtype: :class:`matplotlib.axes`
@@ -3916,7 +3916,7 @@ class StressPost:
         :param string cmap: Matplotlib color map.
         :param bool normalize: If set to true, the CenteredNorm is used to scale the colormap.
             If set to false, the default linear scaling is used.
-        :param \**kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
+        :param kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
 
         :return: Matplotlib axes object
         :rtype: :class:`matplotlib.axes`
@@ -3968,7 +3968,7 @@ class StressPost:
         :param string cmap: Matplotlib color map.
         :param bool normalize: If set to true, the CenteredNorm is used to scale the colormap.
             If set to false, the default linear scaling is used.
-        :param \**kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
+        :param kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
 
         :return: Matplotlib axes object
         :rtype: :class:`matplotlib.axes`
@@ -4018,7 +4018,7 @@ class StressPost:
         :param string cmap: Matplotlib color map.
         :param bool normalize: If set to true, the CenteredNorm is used to scale the colormap.
             If set to false, the default linear scaling is used.
-        :param \**kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
+        :param kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
 
         :return: Matplotlib axes object
         :rtype: :class:`matplotlib.axes`
@@ -4068,7 +4068,7 @@ class StressPost:
         :param string cmap: Matplotlib color map.
         :param bool normalize: If set to true, the CenteredNorm is used to scale the colormap.
             If set to false, the default linear scaling is used.
-        :param \**kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
+        :param kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
 
         :return: Matplotlib axes object
         :rtype: :class:`matplotlib.axes`
@@ -4118,7 +4118,7 @@ class StressPost:
         :param string cmap: Matplotlib color map.
         :param bool normalize: If set to true, the CenteredNorm is used to scale the colormap.
             If set to false, the default linear scaling is used.
-        :param \**kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
+        :param kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
 
         :return: Matplotlib axes object
         :rtype: :class:`matplotlib.axes`
@@ -4168,7 +4168,7 @@ class StressPost:
         :param string cmap: Matplotlib color map.
         :param bool normalize: If set to true, the CenteredNorm is used to scale the colormap.
             If set to false, the default linear scaling is used.
-        :param \**kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
+        :param kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
 
         :return: Matplotlib axes object
         :rtype: :class:`matplotlib.axes`
@@ -4220,7 +4220,7 @@ class StressPost:
         :param string cmap: Matplotlib color map.
         :param bool normalize: If set to true, the CenteredNorm is used to scale the colormap.
             If set to false, the default linear scaling is used.
-        :param \**kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
+        :param kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
 
         :return: Matplotlib axes object
         :rtype: :class:`matplotlib.axes`
@@ -4280,7 +4280,7 @@ class StressPost:
         :param string cmap: Matplotlib color map.
         :param bool normalize: If set to true, the CenteredNorm is used to scale the colormap.
             If set to false, the default linear scaling is used.
-        :param \**kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
+        :param kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
 
         :return: Matplotlib axes object
         :rtype: :class:`matplotlib.axes`
@@ -4340,7 +4340,7 @@ class StressPost:
         :param string cmap: Matplotlib color map.
         :param bool normalize: If set to true, the CenteredNorm is used to scale the colormap.
             If set to false, the default linear scaling is used.
-        :param \**kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
+        :param kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
 
         :return: Matplotlib axes object
         :rtype: :class:`matplotlib.axes`
@@ -4392,7 +4392,7 @@ class StressPost:
         :param float x: x-coordinate of the point to draw Mohr's Circle
         :param float y: y-coordinate of the point to draw Mohr's Circle
         :param string title: Plot title
-        :param \**kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
+        :param kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
 
         :return: Matplotlib axes object
         :rtype: :class:`matplotlib.axes`

--- a/sectionproperties/post/post.py
+++ b/sectionproperties/post/post.py
@@ -25,7 +25,7 @@ def plotting_context(
         This may be a tuple if a 2D array of plots is returned.  The default value of None will
         select the top left plot.
     :type axis_index: Union[None, int, Tuple(int)]
-    :param \**kwargs: Passed to :func:`matplotlib.pyplot.subplots`
+    :param kwargs: Passed to :func:`matplotlib.pyplot.subplots`
     """
 
     if filename:

--- a/sectionproperties/pre/geometry.py
+++ b/sectionproperties/pre/geometry.py
@@ -1248,7 +1248,7 @@ class CompoundGeometry(Geometry):
                     f"If materials are provided, the number of materials in the list must "
                     "match the number of control_points provided.\n"
                     f"len(materials)=={len(materials)}, len(control_points)=={len(control_points)}."
-                    )
+                )
 
         # First, generate all invidual polygons from points and facets
         current_polygon_points = []
@@ -1307,14 +1307,22 @@ class CompoundGeometry(Geometry):
             if materials is pre.DEFAULT_MATERIAL:
                 return CompoundGeometry(
                     [
-                        Geometry(exterior, control_points=control_points[idx], material=materials)
+                        Geometry(
+                            exterior,
+                            control_points=control_points[idx],
+                            material=materials,
+                        )
                         for idx, exterior in enumerate(exteriors)
                     ]
                 )
             else:
                 return CompoundGeometry(
                     [
-                        Geometry(exterior, control_points=control_points[idx], material=materials[idx])
+                        Geometry(
+                            exterior,
+                            control_points=control_points[idx],
+                            material=materials[idx],
+                        )
                         for idx, exterior in enumerate(exteriors)
                     ]
                 )
@@ -1341,19 +1349,22 @@ class CompoundGeometry(Geometry):
                 if materials is pre.DEFAULT_MATERIAL:
 
                     exterior_geometry = Geometry(
-                        punched_exterior, control_points=exterior_control_point, material=materials
+                        punched_exterior,
+                        control_points=exterior_control_point,
+                        material=materials,
                     )
                     punched_exterior_geometries.append(exterior_geometry)
 
                 else:
 
                     exterior_geometry = Geometry(
-                        punched_exterior, control_points=exterior_control_point, material=materials[idx]
+                        punched_exterior,
+                        control_points=exterior_control_point,
+                        material=materials[idx],
                     )
                     punched_exterior_geometries.append(exterior_geometry)
 
             return CompoundGeometry(punched_exterior_geometries)
-
 
     @classmethod
     def from_3dm(cls, filepath: Union[str, pathlib.Path], **kwargs) -> CompoundGeometry:

--- a/sectionproperties/pre/geometry.py
+++ b/sectionproperties/pre/geometry.py
@@ -144,10 +144,10 @@ class Geometry:
             being holes or voids. The point can be located anywhere within the hole region.
             Only one point is required per hole region.
         :vartype holes: list[list[float, float]]
-        :cvar materials: Optional. A list of :class:`~sectionproperties.pre.pre.Material` objects that are to be
-            assigned, in order, to the regions defined by the given control_points. If not given, then
-            the :class:`~sectionproperties.pre.pre.DEFAULT_MATERIAL` will be used for each region.
-        :vartype materials: list[:class:`~sectionproperties.pre.pre.Material`]
+        :cvar material: Optional. A :class:`~sectionproperties.pre.pre.Material` object
+            that is to be assigned. If not given, then the
+            :class:`~sectionproperties.pre.pre.DEFAULT_MATERIAL` will be used.
+        :vartype materials: :class:`~sectionproperties.pre.pre.Material`
         """
         if len(control_points) != 1:
             raise ValueError(
@@ -225,7 +225,7 @@ class Geometry:
         :param filepath:
             File path to the rhino `.3dm` file.
         :type filepath: Union[str, pathlib.Path]
-        :param \**kwargs:
+        :param kwargs:
             See below.
         :raises RuntimeError:
             A RuntimeError is raised if two or more polygons are found.
@@ -290,7 +290,7 @@ class Geometry:
         :param r3dm_brep:
             A Rhino3dm.Brep encoded as a string.
         :type r3dm_brep: str
-        :param \**kwargs:
+        :param kwargs:
             See below.
         :return:
             A Geometry object found in the encoded string.
@@ -871,7 +871,7 @@ class Geometry:
             to indicate no labels. Default is ["control_points"]
         :type labels: list[str]
         :param string title: Plot title
-        :param \**kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
+        :param kwargs: Passed to :func:`~sectionproperties.post.post.plotting_context`
 
         :return: Matplotlib axes object
         :rtype: :class:`matplotlib.axes`
@@ -1336,7 +1336,7 @@ class CompoundGeometry(Geometry):
         :param filepath:
             File path to the rhino `.3dm` file.
         :type filepath: Union[str, pathlib.Path]
-        :param \**kwargs:
+        :param kwargs:
             See below.
         :return:
             A `CompoundGeometry` object.

--- a/sectionproperties/pre/rhino.py
+++ b/sectionproperties/pre/rhino.py
@@ -10,7 +10,7 @@ def load_3dm(r3dm_filepath: Union[pathlib.Path, str], **kwargs) -> List[Polygon]
     :param r3dm_filepath:
         File path to the rhino `.3dm` file.
     :type r3dm_filepath: pathlib.Path or string
-    :param \**kwargs:
+    :param kwargs:
         See below.
     :raises RuntimeError:
         A RuntimeError is raised if no polygons are found in the file.
@@ -64,7 +64,7 @@ def load_brep_encoding(brep: str, **kwargs) -> Polygon:
     :param brep:
         Rhino3dm.Brep encoded as a string.
     :type brep: str
-    :param \**kwargs:
+    :param kwargs:
         See below.
     :raises RuntimeError:
         A RuntimeError is raised if no polygons are found in the encoding.

--- a/sectionproperties/tests/test_sections.py
+++ b/sectionproperties/tests/test_sections.py
@@ -118,13 +118,26 @@ def test_geometry_from_points():
     ]
     control_points = [[0, 0]]
     holes = [[0, 6], [0, -6]]
+    material = Material(
+        name="mat1",
+        elastic_modulus=2,
+        poissons_ratio=0.3,
+        density=1e-6,
+        yield_strength=5,
+        color="grey",
+    )
     new_geom = Geometry.from_points(
-        points=points, facets=facets, control_points=control_points, holes=holes
+        points=points,
+        facets=facets,
+        control_points=control_points,
+        holes=holes,
+        material=material,
     )
     wkt_test_geom = shapely.wkt.loads(
         "POLYGON ((6 10, 6 -10, -6 -10, -6 10, 6 10), (-4 4, 4 4, 4 8, -4 8, -4 4), (4 -8, 4 -4, -4 -4, -4 -8, 4 -8))"
     )
     assert (new_geom.geom - wkt_test_geom) == Polygon()
+    assert (new_geom.material) == material
 
 
 def test_compound_geometry_from_points():
@@ -162,12 +175,32 @@ def test_compound_geometry_from_points():
         [9, 6],
     ]
     control_points = [[0, 0], [0, -2 * a - t / 2]]
-    new_geom = CompoundGeometry.from_points(points, facets, control_points)
+    mat1 = Material(
+        name="mat1",
+        elastic_modulus=2,
+        poissons_ratio=0.3,
+        density=1e-6,
+        yield_strength=5,
+        color="grey",
+    )
+    mat2 = Material(
+        name="mat2",
+        elastic_modulus=5,
+        poissons_ratio=0.2,
+        density=2e-6,
+        yield_strength=10,
+        color="blue",
+    )
+    materials = [mat1, mat2]
+    new_geom = CompoundGeometry.from_points(points, facets, control_points, materials=materials)
     wkt_test_geom = shapely.wkt.loads(
         "MULTIPOLYGON (((-0.05 -2, 0.05 -2, 0.05 -0.05, 1 -0.05, 1 0.05, -0.05 0.05, -0.05 -2)), ((-1 -2, 1 -2, 1 -2.1, -1 -2.1, -1 -2)))"
     )
     assert (new_geom.geom - wkt_test_geom) == Polygon()
 
+    # test materials
+    for idx, geom in enumerate(new_geom.geoms):
+        assert geom.material == materials[idx]
 
 def test_multi_nested_compound_geometry_from_points():
     """
@@ -215,8 +248,33 @@ def test_multi_nested_compound_geometry_from_points():
     ]
     control_points = [[-43.75, 0.0], [-31.25, 0.0], [-18.75, 0.0]]
     holes = [[0, 0]]
+    mat1 = Material(
+        name="mat1",
+        elastic_modulus=2,
+        poissons_ratio=0.3,
+        density=1e-6,
+        yield_strength=5,
+        color="grey",
+    )
+    mat2 = Material(
+        name="mat2",
+        elastic_modulus=5,
+        poissons_ratio=0.2,
+        density=2e-6,
+        yield_strength=10,
+        color="blue",
+    )
+    mat3 = Material(
+        name="mat3",
+        elastic_modulus=1,
+        poissons_ratio=0.25,
+        density=1.5e-6,
+        yield_strength=3,
+        color="green",
+    )
+    materials = [mat1, mat2, mat3]
     nested_compound = CompoundGeometry.from_points(
-        points=points, facets=facets, control_points=control_points, holes=holes
+        points=points, facets=facets, control_points=control_points, holes=holes, materials=materials
     )
     wkt_test_geom = shapely.wkt.loads(
         "MULTIPOLYGON (((50 50, 50 -50, -50 -50, -50 50, 50 50), (12.5 12.5, -12.5 12.5, -12.5 -12.5, 12.5 -12.5, 12.5 12.5)), ((-37.5 -37.5, -37.5 37.5, 37.5 37.5, 37.5 -37.5, -37.5 -37.5), (12.5 12.5, -12.5 12.5, -12.5 -12.5, 12.5 -12.5, 12.5 12.5)), ((-25 -25, -25 25, 25 25, 25 -25, -25 -25), (12.5 12.5, -12.5 12.5, -12.5 -12.5, 12.5 -12.5, 12.5 12.5)))"
@@ -229,6 +287,10 @@ def test_multi_nested_compound_geometry_from_points():
         (-18.75, 0.0),
     ]
     assert nested_compound.holes == [(0, 0)]
+
+    # test materials
+    for idx, geom in enumerate(nested_compound.geoms):
+        assert geom.material == materials[idx]
 
     # Section contains overlapping geometries which will result in potentially incorrect
     # plastic properties calculation (depends on user intent and geometry).

--- a/sectionproperties/tests/test_sections.py
+++ b/sectionproperties/tests/test_sections.py
@@ -192,7 +192,9 @@ def test_compound_geometry_from_points():
         color="blue",
     )
     materials = [mat1, mat2]
-    new_geom = CompoundGeometry.from_points(points, facets, control_points, materials=materials)
+    new_geom = CompoundGeometry.from_points(
+        points, facets, control_points, materials=materials
+    )
     wkt_test_geom = shapely.wkt.loads(
         "MULTIPOLYGON (((-0.05 -2, 0.05 -2, 0.05 -0.05, 1 -0.05, 1 0.05, -0.05 0.05, -0.05 -2)), ((-1 -2, 1 -2, 1 -2.1, -1 -2.1, -1 -2)))"
     )
@@ -201,6 +203,7 @@ def test_compound_geometry_from_points():
     # test materials
     for idx, geom in enumerate(new_geom.geoms):
         assert geom.material == materials[idx]
+
 
 def test_multi_nested_compound_geometry_from_points():
     """
@@ -274,7 +277,11 @@ def test_multi_nested_compound_geometry_from_points():
     )
     materials = [mat1, mat2, mat3]
     nested_compound = CompoundGeometry.from_points(
-        points=points, facets=facets, control_points=control_points, holes=holes, materials=materials
+        points=points,
+        facets=facets,
+        control_points=control_points,
+        holes=holes,
+        materials=materials,
     )
     wkt_test_geom = shapely.wkt.loads(
         "MULTIPOLYGON (((50 50, 50 -50, -50 -50, -50 50, 50 50), (12.5 12.5, -12.5 12.5, -12.5 -12.5, 12.5 -12.5, 12.5 12.5)), ((-37.5 -37.5, -37.5 37.5, 37.5 37.5, 37.5 -37.5, -37.5 -37.5), (12.5 12.5, -12.5 12.5, -12.5 -12.5, 12.5 -12.5, 12.5 12.5)), ((-25 -25, -25 25, 25 25, 25 -25, -25 -25), (12.5 12.5, -12.5 12.5, -12.5 -12.5, 12.5 -12.5, 12.5 12.5)))"


### PR DESCRIPTION
As per #199, updates implementation of `CompoundGeometry.from_points()` to include a list of materials that are assumed to be in the same order as the control_points.