### PR TITLE
Feat stress elm local

### DIFF
--- a/sectionproperties/analysis/fea.py
+++ b/sectionproperties/analysis/fea.py
@@ -43,18 +43,18 @@ class Tri6:
     def __post_init__(self):
         # Create a mapping from global elm to local elm (unit triangle)
         # The result is used in the global to local mapping: (eta, xi) = _M(x_global-_x0), zeta = 1-eta-xi
-        (p0,p1,self._x0) = self.coords[:,0:3].transpose()
+        (p0, p1, self._x0) = self.coords[:, 0:3].transpose()
         # Shift the triangle so the x_3 vertex (global) is on the origin ((eta, xi, zeta) = (0,0,1))
         # Aside: This is chosen to be consistent with the shape function definitions.
         # At (0,0,1), N3=1, N1=N2=N4=...=0 (see Theoretical Background documentation)
         # since (x, y) = (sum(N_i(eta,xi,zeta)*x_i),  sum(N_i(eta,xi,zeta)*y_i)
         # then at (0,0,1): (x,y) = (x_3,y_3). ie: (x_3, y_3) => (0,0,1)
-        r0 = p0-self._x0
-        r1 = p1-self._x0
+        r0 = p0 - self._x0
+        r1 = p1 - self._x0
         # Asseble the equations to solve for the transformation for the unit triangle
-        x = np.array([r0,r1]).transpose()
-        b = np.array([[1, 0],[0, 1]])
-        self._M = np.linalg.solve(x,b)
+        x = np.array([r0, r1]).transpose()
+        b = np.array([[1, 0], [0, 1]])
+        self._M = np.linalg.solve(x, b)
 
     def __repr__(self):
         rep = f"el_id: {self.el_id}\ncoords: {self.coords}\nnode_ids: {self.node_ids}\nmaterial: {self.material}"
@@ -582,7 +582,7 @@ class Tri6:
         phi_shear,
         Delta_s,
     ):
-        """Calculates the stress at a point `p` within the element resulting from a specified loading. 
+        """Calculates the stress at a point `p` within the element resulting from a specified loading.
 
         :param p: Point (x,y) in the global coordinate system that is within the element.
         :type p: :class:`numpy.ndarray`
@@ -666,9 +666,9 @@ class Tri6:
         p_local = self.local_coord(p)
         # get the value of the basis functions at p_local
         N = shape_function_only(p_local)
-        
+
         # interpolate the nodal values to p_local and add the results
-        ( 
+        (
             sig_zz_n_p,
             sig_zz_mxx_p,
             sig_zz_myy_p,
@@ -680,19 +680,24 @@ class Tri6:
             sig_zy_vx_p,
             sig_zx_vy_p,
             sig_zy_vy_p,
-        ) = np.dot( np.array([
-            sig_zz_n_el,
-            sig_zz_mxx_el,
-            sig_zz_myy_el,
-            sig_zz_m11_el,
-            sig_zz_m22_el,
-            sig_zx_mzz_el,
-            sig_zy_mzz_el,
-            sig_zx_vx_el,
-            sig_zy_vx_el,
-            sig_zx_vy_el,
-            sig_zy_vy_el,
-        ]), N)
+        ) = np.dot(
+            np.array(
+                [
+                    sig_zz_n_el,
+                    sig_zz_mxx_el,
+                    sig_zz_myy_el,
+                    sig_zz_m11_el,
+                    sig_zz_m22_el,
+                    sig_zx_mzz_el,
+                    sig_zy_mzz_el,
+                    sig_zx_vx_el,
+                    sig_zy_vx_el,
+                    sig_zx_vy_el,
+                    sig_zy_vy_el,
+                ]
+            ),
+            N,
+        )
         return (
             sig_zz_n_p,
             sig_zz_mxx_p,
@@ -743,7 +748,7 @@ class Tri6:
             return False
 
     def local_coord(self, p):
-        """Map a point `p` = (x, y) in the global coordinate system onto a 
+        """Map a point `p` = (x, y) in the global coordinate system onto a
         point (eta, xi, zeta) in the local coordinate system.
 
         :param p: Global coordinate (x,y)
@@ -751,9 +756,10 @@ class Tri6:
         :return: Point in local coordinate (eta, xi, zeta)
         :rtype: :class:`numpy.ndarray`
         """
-        (eta, xi) = np.dot(self._M, p-self._x0) 
+        (eta, xi) = np.dot(self._M, p - self._x0)
         zeta = 1 - eta - xi
         return np.array([eta, xi, zeta])
+
 
 def gauss_points(n):
     """Returns the Gaussian weights and locations for *n* point Gaussian integration of a quadratic
@@ -857,6 +863,7 @@ def shape_function(coords, gauss_point):
 
     return (N, B, j)
 
+
 def shape_function_only(p):
     """The values of the Tri6 shape function at a point `p`.
 
@@ -879,6 +886,7 @@ def shape_function_only(p):
             4 * eta * zeta,
         ]
     )
+
 
 def extrapolate_to_nodes(w):
     """Extrapolates results at six Gauss points to the six nodes of a quadratic triangular element.

--- a/sectionproperties/analysis/fea.py
+++ b/sectionproperties/analysis/fea.py
@@ -698,9 +698,7 @@ class Tri6:
             ),
             N,
         )
-        sig_zz_m_p = (
-            sig_zz_mxx_p + sig_zz_myy_p + sig_zz_m11_p + sig_zz_m22_p 
-        )
+        sig_zz_m_p = sig_zz_mxx_p + sig_zz_myy_p + sig_zz_m11_p + sig_zz_m22_p
         sig_zx_v_p = sig_zx_vx_p + sig_zx_vy_p
         sig_zy_v_p = sig_zy_vx_p + sig_zy_vy_p
         sig_zy_p = sig_zy_mzz_p + sig_zy_v_p

--- a/sectionproperties/analysis/fea.py
+++ b/sectionproperties/analysis/fea.py
@@ -698,18 +698,19 @@ class Tri6:
             ),
             N,
         )
+        sig_zz_m_p = (
+            sig_zz_mxx_p + sig_zz_myy_p + sig_zz_m11_p + sig_zz_m22_p 
+        )
+        sig_zx_v_p = sig_zx_vx_p + sig_zx_vy_p
+        sig_zy_v_p = sig_zy_vx_p + sig_zy_vy_p
+        sig_zy_p = sig_zy_mzz_p + sig_zy_v_p
+        sig_zz_p = sig_zz_n_p + sig_zz_m_p
+        sig_zx_p = sig_zx_mzz_p + sig_zx_v_p
+        sig_zy_p = sig_zy_mzz_p + sig_zy_v_p
         return (
-            sig_zz_n_p,
-            sig_zz_mxx_p,
-            sig_zz_myy_p,
-            sig_zz_m11_p,
-            sig_zz_m22_p,
-            sig_zx_mzz_p,
-            sig_zy_mzz_p,
-            sig_zx_vx_p,
-            sig_zy_vx_p,
-            sig_zx_vy_p,
-            sig_zy_vy_p,
+            sig_zz_p,
+            sig_zx_p,
+            sig_zy_p,
         )
 
     def point_within_element(self, pt):

--- a/sectionproperties/analysis/section.py
+++ b/sectionproperties/analysis/section.py
@@ -27,9 +27,9 @@ import sectionproperties.analysis.fea as fea
 import sectionproperties.analysis.solver as solver
 import sectionproperties.post.post as post
 
-from shapely.geometry import asPoint, Polygon
+from shapely.geometry import Polygon
 from shapely.strtree import STRtree
-
+from shapely.geometry import Point
 
 class Section:
     """Class for structural cross-sections.
@@ -2150,7 +2150,7 @@ class Section:
         Vy=0,
         agg_func=np.average,
     ) -> Tuple[float]:
-        """Calaculates the stress at a point within an element for given design actions
+        """Calculates the stress at a point within an element for given design actions
         and returns *(sigma_zz, tau_xz, tau_yz)*
 
         :param pt: The point. A list of the x and y coordinate
@@ -2168,7 +2168,6 @@ class Section:
             (sigma_zz, tau_xz, tau_yz) are retrieved from each element and combined according to this function.
             By default, `numpy.average` is used.
         :type agg_function: function, optional
-        :return: Resultant normal and shear stresses (sigma_zz, tau_xz, tau_yz)
         :return: Resultant normal and shear stresses list[(sigma_zz, tau_xz, tau_yz)]. If a point it not in the
             section then None is returned.
         :rtype: Union[Tuple[float, float, float], None]
@@ -2191,7 +2190,7 @@ class Section:
         Vy=0,
         agg_func=np.average,
     ) -> List[Tuple]:
-        """Calaculates the stress at a set of points within an element for given design actions
+        """Calculates the stress at a set of points within an element for given design actions
         and returns *(sigma_zz, tau_xz, tau_yz)*
 
         :param pts: The points. A list of several x and y coordinates
@@ -2241,7 +2240,7 @@ class Section:
         }
 
         for pt in pts:
-            query_geom = asPoint(pt)
+            query_geom = Point(pt)
             tri_ids = [
                 self.poly_mesh_idx[id(poly)]
                 for poly in self.mesh_search_tree.query(query_geom)

--- a/sectionproperties/analysis/section.py
+++ b/sectionproperties/analysis/section.py
@@ -30,6 +30,7 @@ import sectionproperties.post.post as post
 from shapely.geometry import asPoint, Polygon
 from shapely.strtree import STRtree
 
+
 class Section:
     """Class for structural cross-sections.
 
@@ -188,7 +189,10 @@ class Section:
         self.mesh_attributes = attributes
 
         # create the search tree
-        p_mesh = [Polygon(self.geometry.mesh["vertices"][tri][0:3]) for tri in self.geometry.mesh["triangles"]]
+        p_mesh = [
+            Polygon(self.geometry.mesh["vertices"][tri][0:3])
+            for tri in self.geometry.mesh["triangles"]
+        ]
         self.poly_mesh_idx = dict((id(poly), i) for i, poly in enumerate(p_mesh))
         self.mesh_search_tree = STRtree(p_mesh)
 
@@ -2134,7 +2138,17 @@ class Section:
         )
 
     def get_stress_at_point(
-        self, pt: List[float], N=0, Mxx=0, Myy=0, M11=0, M22=0, Mzz=0, Vx=0, Vy=0, agg_func=np.average
+        self,
+        pt: List[float],
+        N=0,
+        Mxx=0,
+        Myy=0,
+        M11=0,
+        M22=0,
+        Mzz=0,
+        Vx=0,
+        Vy=0,
+        agg_func=np.average,
     ) -> Tuple[float]:
         """Calaculates the stress at a point within an element for given design actions
         and returns *(sigma_zz, tau_xz, tau_yz)*
@@ -2157,12 +2171,23 @@ class Section:
         :return: Resultant normal and shear stresses (sigma_zz, tau_xz, tau_yz)
         :rtype: tuple(float, float, float)
         """
-        sigs = self.get_stress_at_points([pt], N, Mxx, Myy, M11, M22, Mzz, Vx, Vy, agg_func)
+        sigs = self.get_stress_at_points(
+            [pt], N, Mxx, Myy, M11, M22, Mzz, Vx, Vy, agg_func
+        )
         return next(sigs)
 
-
     def get_stress_at_points(
-        self, pts: List[List[float]], N=0, Mxx=0, Myy=0, M11=0, M22=0, Mzz=0, Vx=0, Vy=0, agg_func=np.average
+        self,
+        pts: List[List[float]],
+        N=0,
+        Mxx=0,
+        Myy=0,
+        M11=0,
+        M22=0,
+        Mzz=0,
+        Vx=0,
+        Vy=0,
+        agg_func=np.average,
     ) -> List[Tuple]:
         """Calaculates the stress at a set of points within an element for given design actions
         and returns *(sigma_zz, tau_xz, tau_yz)*
@@ -2214,10 +2239,14 @@ class Section:
 
         for pt in pts:
             query_geom = asPoint(pt)
-            tri_ids = [self.poly_mesh_idx[id(poly)] for poly in self.mesh_search_tree.query(query_geom) if poly.intersects(query_geom)]
-            if len(tri_ids) ==0:
+            tri_ids = [
+                self.poly_mesh_idx[id(poly)]
+                for poly in self.mesh_search_tree.query(query_geom)
+                if poly.intersects(query_geom)
+            ]
+            if len(tri_ids) == 0:
                 sig = None
-            elif len(tri_ids)==1:
+            elif len(tri_ids) == 1:
                 tri = self.elements[tri_ids[0]]
                 sig = tri.local_element_stress(
                     p=pt,
@@ -2231,7 +2260,8 @@ class Section:
                 sigs = []
                 for idx in tri_ids:
                     tri = self.elements[idx]
-                    sigs.append(tri.local_element_stress(
+                    sigs.append(
+                        tri.local_element_stress(
                             p=pt,
                             **action,
                             **sect_prop,
@@ -2246,6 +2276,7 @@ class Section:
                     agg_func([sig[2] for sig in sigs]),
                 )
             yield sig
+
 
 class PlasticSection:
     """Class for the plastic analysis of cross-sections.

--- a/sectionproperties/analysis/section.py
+++ b/sectionproperties/analysis/section.py
@@ -31,6 +31,7 @@ from shapely.geometry import Polygon
 from shapely.strtree import STRtree
 from shapely.geometry import Point
 
+
 class Section:
     """Class for structural cross-sections.
 

--- a/sectionproperties/analysis/section.py
+++ b/sectionproperties/analysis/section.py
@@ -1,4 +1,4 @@
-from typing import Union, Optional, Tuple
+from typing import List, Union, Optional, Tuple
 
 import copy
 from dataclasses import dataclass, asdict
@@ -2125,6 +2125,81 @@ class Section:
             self.section_props.sf_22_plus,
             self.section_props.sf_22_minus,
         )
+
+
+    def get_stress_at_point(
+        self,
+        pt: List[float],
+        N=0,
+        Mxx=0,
+        Myy=0,
+        M11=0,
+        M22=0,
+        Mzz=0,
+        Vx=0,
+        Vy=0
+        ) -> Tuple[float]:
+        """Calaculates the stress at a point wiithin an element for given design actions
+        and returns *(sigma_zz, tau_xz, tau_yz)*
+        
+        :param pt: The point. A list of the x and y coordinate
+        :type pt: list[float, float]
+        :param float N: Axial force
+        :param float Vx: Shear force acting in the x-direction
+        :param float Vy: Shear force acting in the y-direction
+        :param float Mxx: Bending moment about the centroidal xx-axis
+        :param float Myy: Bending moment about the centroidal yy-axis
+        :param float M11: Bending moment about the centroidal 11-axis
+        :param float M22: Bending moment about the centroidal 22-axis
+        :param float Mzz: Torsion moment about the centroidal zz-axis
+        :return: Resultant normal and shear stresses (sigma_zz, tau_xz, tau_yz)
+        :rtype: tuple(float, float, float)
+        """
+
+        action = { 
+            'N': N,
+            'Mxx': Mxx,
+            'Myy': Myy,
+            'M11': M11,
+            'M22': M22,
+            'Mzz': Mzz,
+            'Vx': Vx,
+            'Vy': Vy
+        }
+
+        sect_prop = {
+            'ea':  self.section_props.ea,
+            'cx':  self.section_props.cx,
+            'cy':  self.section_props.cy,
+            'ixx':  self.section_props.ixx_c,
+            'iyy':  self.section_props.iyy_c,
+            'ixy':  self.section_props.ixy_c,
+            'i11':  self.section_props.i11_c,
+            'i22':  self.section_props.i22_c,
+            'phi':  self.section_props.phi,
+            'j':  self.section_props.j,
+            'Delta_s':  self.section_props.Delta_s,
+            'nu':  self.section_props.nu_eff,
+        }
+        
+        # find the Tri6 element containing the point
+        tri_id = None
+        for (idx , tri) in enumerate(self.elements):
+            if tri.point_within_element(pt):
+                tri_id = idx
+        tri = self.elements[tri_id]
+
+        # get the stess at the point
+        sigs = tri.local_element_stress(
+            p=pt,
+            **action,
+            **sect_prop,
+            omega=self.section_props.omega[tri.node_ids],
+            psi_shear=self.section_props.psi_shear[tri.node_ids],
+            phi_shear=self.section_props.phi_shear[tri.node_ids]
+            )
+
+        return sigs
 
 
 class PlasticSection:

--- a/sectionproperties/analysis/section.py
+++ b/sectionproperties/analysis/section.py
@@ -2169,7 +2169,9 @@ class Section:
             By default, `numpy.average` is used.
         :type agg_function: function, optional
         :return: Resultant normal and shear stresses (sigma_zz, tau_xz, tau_yz)
-        :rtype: tuple(float, float, float)
+        :return: Resultant normal and shear stresses list[(sigma_zz, tau_xz, tau_yz)]. If a point it not in the
+            section then None is returned.
+        :rtype: Union[Tuple[float, float, float], None]
         """
         sigs = self.get_stress_at_points(
             [pt], N, Mxx, Myy, M11, M22, Mzz, Vx, Vy, agg_func
@@ -2207,8 +2209,9 @@ class Section:
             (sigma_zz, tau_xz, tau_yz) are retrieved from each element and combined according to this function.
             By default, `numpy.average` is used.
         :type agg_function: function, optional
-        :return: Resultant normal and shear stresses list[(sigma_zz, tau_xz, tau_yz)]
-        :rtype: list[tuple(float, float, float)]
+        :return: Resultant normal and shear stresses list[(sigma_zz, tau_xz, tau_yz)]. If a point it not in the
+            section then None is returned for that element in the list.
+        :rtype: List[Union[Tuple[float, float, float], None]]
         """
 
         action = {

--- a/sectionproperties/analysis/section.py
+++ b/sectionproperties/analysis/section.py
@@ -2126,22 +2126,12 @@ class Section:
             self.section_props.sf_22_minus,
         )
 
-
     def get_stress_at_point(
-        self,
-        pt: List[float],
-        N=0,
-        Mxx=0,
-        Myy=0,
-        M11=0,
-        M22=0,
-        Mzz=0,
-        Vx=0,
-        Vy=0
-        ) -> Tuple[float]:
+        self, pt: List[float], N=0, Mxx=0, Myy=0, M11=0, M22=0, Mzz=0, Vx=0, Vy=0
+    ) -> Tuple[float]:
         """Calaculates the stress at a point wiithin an element for given design actions
         and returns *(sigma_zz, tau_xz, tau_yz)*
-        
+
         :param pt: The point. A list of the x and y coordinate
         :type pt: list[float, float]
         :param float N: Axial force
@@ -2156,35 +2146,35 @@ class Section:
         :rtype: tuple(float, float, float)
         """
 
-        action = { 
-            'N': N,
-            'Mxx': Mxx,
-            'Myy': Myy,
-            'M11': M11,
-            'M22': M22,
-            'Mzz': Mzz,
-            'Vx': Vx,
-            'Vy': Vy
+        action = {
+            "N": N,
+            "Mxx": Mxx,
+            "Myy": Myy,
+            "M11": M11,
+            "M22": M22,
+            "Mzz": Mzz,
+            "Vx": Vx,
+            "Vy": Vy,
         }
 
         sect_prop = {
-            'ea':  self.section_props.ea,
-            'cx':  self.section_props.cx,
-            'cy':  self.section_props.cy,
-            'ixx':  self.section_props.ixx_c,
-            'iyy':  self.section_props.iyy_c,
-            'ixy':  self.section_props.ixy_c,
-            'i11':  self.section_props.i11_c,
-            'i22':  self.section_props.i22_c,
-            'phi':  self.section_props.phi,
-            'j':  self.section_props.j,
-            'Delta_s':  self.section_props.Delta_s,
-            'nu':  self.section_props.nu_eff,
+            "ea": self.section_props.ea,
+            "cx": self.section_props.cx,
+            "cy": self.section_props.cy,
+            "ixx": self.section_props.ixx_c,
+            "iyy": self.section_props.iyy_c,
+            "ixy": self.section_props.ixy_c,
+            "i11": self.section_props.i11_c,
+            "i22": self.section_props.i22_c,
+            "phi": self.section_props.phi,
+            "j": self.section_props.j,
+            "Delta_s": self.section_props.Delta_s,
+            "nu": self.section_props.nu_eff,
         }
-        
+
         # find the Tri6 element containing the point
         tri_id = None
-        for (idx , tri) in enumerate(self.elements):
+        for (idx, tri) in enumerate(self.elements):
             if tri.point_within_element(pt):
                 tri_id = idx
         tri = self.elements[tri_id]
@@ -2196,8 +2186,8 @@ class Section:
             **sect_prop,
             omega=self.section_props.omega[tri.node_ids],
             psi_shear=self.section_props.psi_shear[tri.node_ids],
-            phi_shear=self.section_props.phi_shear[tri.node_ids]
-            )
+            phi_shear=self.section_props.phi_shear[tri.node_ids],
+        )
 
         return sigs
 

--- a/sectionproperties/analysis/section.py
+++ b/sectionproperties/analysis/section.py
@@ -2177,6 +2177,10 @@ class Section:
         for (idx, tri) in enumerate(self.elements):
             if tri.point_within_element(pt):
                 tri_id = idx
+
+        if tri_id is None:
+            raise ValueError(f"The point {pt} is outside of the section boundary.")
+
         tri = self.elements[tri_id]
 
         # get the stess at the point


### PR DESCRIPTION
This is draft for some of basic elements of issue #175. It gives the ability for the Tri6 element to determine its stress at a point within its domain.

Known limitations:
1. The mappings in `Tri6.local_coord` that take a global coordinate and maps it to a local coordinate (or physical coordinate to a natural coordinate) are based on alphine transformations and are not general enough for isoparametric triangular elements. The mappings are sufficient for "straight line" Tri6 elements. I believe the underlying mesher [`triangle`](http://www.cs.cmu.edu/~quake/triangle.html) is limited to "straight line" Tri6's.

In it's current state this can be used as follows:
```python
import sectionproperties.pre.library.steel_sections as steel_sections
from sectionproperties.analysis.section import Section
import sectionproperties.analysis.fea as fea
import numpy as np
import matplotlib.pyplot as plt
from matplotlib.gridspec import GridSpec

# Create a 150x100x6 RHS on its side
geometry = steel_sections.rectangular_hollow_section(d=100, b=150, t=6, r_out=15, n_r=8)

# Create a mesh and section object. For the mesh, use a maximum area of 2
geometry.create_mesh(mesh_sizes=[100])
section = Section(geometry)
section.plot_mesh()

# Perform a geometry and warping analysis
section.calculate_geometric_properties()
section.calculate_warping_properties()

# Section properties needed for local stress
sect_prop = {
    'ea':  section.section_props.ea,
    'cx':  section.section_props.cx,
    'cy':  section.section_props.cy,
    'ixx':  section.section_props.ixx_c,
    'iyy':  section.section_props.iyy_c,
    'ixy':  section.section_props.ixy_c,
    'i11':  section.section_props.i11_c,
    'i22':  section.section_props.i22_c,
    'phi':  section.section_props.phi,
    'j':  section.section_props.j,
    'Delta_s':  section.section_props.Delta_s,
    'nu':  section.section_props.nu_eff,
}

# Perform a stress analysis with Mx = 5 kN.m; Vx = 10 kN and Mzz = 3 kN.m
state = {
    'N': 0,
    'Mxx': 5e6,
    'Myy': 0,
    'M11': 0,
    'M22': 0,
    'Mzz': 3e6,
    'Vx': 10e3,
    'Vy': 0
}
case1 = section.calculate_stress(**state)

# set up plots
fig = plt.figure()

gs = GridSpec(2, 2, figure=fig)
ax1 = fig.add_subplot(gs[0, :])
ax2 = fig.add_subplot(gs[1, 0])
ax3 = fig.add_subplot(gs[1, 1])

# Plot the bending stress for case1
case1.plot_stress_v_zx(pausr=False, render=False, ax=ax1)

def getElementStess(p):

    # find the Tri6 element containing the point
    tri_id = None
    for (idx , tri) in enumerate(section.elements):
        if tri.point_within_element(p):
            tri_id = idx
    tri = section.elements[tri_id]

    # get the stess at the point
    sigs = tri.local_element_stress(
        p=p,
        **state,
        **sect_prop,
        omega=section.section_props.omega[tri.node_ids],
        psi_shear=section.section_props.psi_shear[tri.node_ids],
        phi_shear=section.section_props.phi_shear[tri.node_ids]
        )

    return sigs

# get and plot the stress at points
s = []
x = []
y = []
for ii in np.arange(5.015,148.99,4):
    # global point of interest
    p = np.array([ii,4.5])
    y.append(p[1])
    x.append(p[0])
    s.append(getElementStess(p)[7])

ax1.plot(x,y, c="green", marker='o', alpha=.6)
ax2.plot(x,s, c="green", marker='o')

s = []
x = []
y = []
for ii in np.arange(5.015,94.99,3):
    # global point of interest
    p = np.array([5, ii])
    y.append(p[1])
    x.append(p[0])
    s.append(getElementStess(p)[7])
ax1.plot(x,y, c="blue", marker='o',alpha=.6)
ax3.plot(y,s, c="blue", marker='o')

plt.show()
```