### PR TITLE
Fix legend formatting

### DIFF
--- a/sectionproperties/post/post.py
+++ b/sectionproperties/post/post.py
@@ -7,9 +7,7 @@ from sectionproperties.pre.pre import DEFAULT_MATERIAL
 
 
 @contextlib.contextmanager
-def plotting_context(
-    ax=None, pause=True, title="", filename="", render=True, axis_index=None, **kwargs
-):
+def plotting_context(ax=None, pause=True, title="", filename="", render=True, axis_index=None, **kwargs):
     """Executes code required to set up a matplotlib figure.
 
     :param ax: Axes object on which to plot
@@ -49,9 +47,7 @@ def plotting_context(
         except (AttributeError, TypeError):
             pass  # only 1 axis, not an array
         except IndexError as exc:
-            raise ValueError(
-                f"axis_index={axis_index} is not compatible with arguments to subplots: {kwargs}"
-            ) from exc
+            raise ValueError(f"axis_index={axis_index} is not compatible with arguments to subplots: {kwargs}") from exc
     else:
         fig = ax.get_figure()
         ax_supplied = True
@@ -60,15 +56,15 @@ def plotting_context(
 
     yield fig, ax
 
+    # if no axes was supplied, finish the plot and return the figure and axes
+    plt.tight_layout()
+
     ax.set_aspect("equal", anchor="C")
     ax.set_title(title)
 
     if ax_supplied:
         # if an axis was supplied, don't continue with displaying or configuring the plot
         return
-
-    # if no axes was supplied, finish the plot and return the figure and axes
-    plt.tight_layout()
 
     if filename:
         fig.savefig(filename, dpi=fig.dpi)

--- a/sectionproperties/post/post.py
+++ b/sectionproperties/post/post.py
@@ -7,7 +7,9 @@ from sectionproperties.pre.pre import DEFAULT_MATERIAL
 
 
 @contextlib.contextmanager
-def plotting_context(ax=None, pause=True, title="", filename="", render=True, axis_index=None, **kwargs):
+def plotting_context(
+    ax=None, pause=True, title="", filename="", render=True, axis_index=None, **kwargs
+):
     """Executes code required to set up a matplotlib figure.
 
     :param ax: Axes object on which to plot
@@ -47,7 +49,9 @@ def plotting_context(ax=None, pause=True, title="", filename="", render=True, ax
         except (AttributeError, TypeError):
             pass  # only 1 axis, not an array
         except IndexError as exc:
-            raise ValueError(f"axis_index={axis_index} is not compatible with arguments to subplots: {kwargs}") from exc
+            raise ValueError(
+                f"axis_index={axis_index} is not compatible with arguments to subplots: {kwargs}"
+            ) from exc
     else:
         fig = ax.get_figure()
         ax_supplied = True
@@ -56,12 +60,11 @@ def plotting_context(ax=None, pause=True, title="", filename="", render=True, ax
 
     yield fig, ax
 
-    # if no axes was supplied, finish the plot and return the figure and axes
-    plt.tight_layout()
-
-    ax.set_aspect("equal", anchor="C")
     ax.set_title(title)
+    plt.tight_layout()
+    ax.set_aspect("equal", anchor="C")
 
+    # if no axes was supplied, finish the plot and return the figure and axes
     if ax_supplied:
         # if an axis was supplied, don't continue with displaying or configuring the plot
         return


### PR DESCRIPTION
@robbievanleeuwen, I believe this addresses #188 

I've only tested it briefly on a few examples where I previously had legend formatting issues since it was so intermittent

But I think the issue was calling `tight_layout()` after setting the aspect ratio for the plot did something weird for certain aspect ratio plots. Calling it beforehand seems to work as intended. 