### PR TITLE
Added check for when control_point is an instance shapely.geometry.Point

### DIFF
--- a/sectionproperties/pre/geometry.py
+++ b/sectionproperties/pre/geometry.py
@@ -53,7 +53,7 @@ class Geometry:
         self,
         geom: shapely.geometry.Polygon,
         material: pre.Material = pre.DEFAULT_MATERIAL,
-        control_points: Optional[List[float, float]] = None,
+        control_points: Optional[Union[Point, List[float, float]]] = None,
         tol=12,
     ):
         """Inits the Geometry class."""
@@ -64,7 +64,9 @@ class Geometry:
                 f"Argument is not a valid shapely.geometry.Polygon object: {repr(geom)}"
             )
         self.assigned_control_point = None
-        if control_points is not None and len(control_points) == 2:
+        if control_points is not None and (
+            isinstance(control_points, Point) or len(control_points) == 2
+        ):
             self.assigned_control_point = Point(control_points)
         self.tol = (
             tol  # Represents num of decimal places of precision for point locations


### PR DESCRIPTION
Fixes an error that sometimes comes up during difference operations. The error states that `Cannot perform difference between these two geometries...` and it is thrown because another error is caused during instantiation of the `Geometry` instance. The error occurs because the value of `control_point` being passed is an instance of `shapely.geometry.Point` instead of the assumed `list[float, float]`. This condition occurs when a control_point has been assigned and is being carried through an operation. 

This PR acknowledges that a control_point of type `shapely.geometry.Point` is a valid value and updates the function signature and check to match. 