### PR TITLE
Additional sections for concrete_sections

### DIFF
--- a/sectionproperties/pre/library/concrete_sections.py
+++ b/sectionproperties/pre/library/concrete_sections.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, Optional
 import numpy as np
 from shapely.geometry import Polygon
 import sectionproperties.pre.pre as pre
@@ -133,11 +133,11 @@ def concrete_rectangular_section(
 def concrete_column_section(
     b: float,
     d: float,
-    dia_bar: float,
-    bar_area: float,
     cover: float,
     n_bars_b: int,
     n_bars_d: int,
+    dia_bar: float,
+    bar_area: Optional[float] = None,
     conc_mat: pre.Material = pre.DEFAULT_MATERIAL,
     steel_mat: pre.Material = pre.DEFAULT_MATERIAL,
     filled: bool = False,
@@ -150,11 +150,13 @@ def concrete_column_section(
 
     :param float b: Concrete section width, parallel to the x-axis
     :param float d: Concrete section depth, parallel to the y-axis
-    :param float dia_bar: Diameter of reinforcing bars. Used only for calculating bar location.
-    :param float bar_area: Area of reinforcing bars. Used for section capacity calculations.
     :param float cover: Clear cover, calculated as distance from edge of reinforcing bar to edge of section.
     :param int n_bars_b: Number of bars placed across the width of the section, minimum 2.
     :param int n_bars_d: Number of bars placed across the depth of the section, minimum 2.
+    :param float dia_bar: Diameter of reinforcing bars. Used for calculating bar placement and,
+        optionally, for calculating the bar area for section capacity calculations.
+    :param Optional[float] bar_area: Area of reinforcing bars. Used for section capacity calculations.
+        If not provided, then dia_bar will be used to calculate the bar area.
     :param Optional[sectionproperties.pre.pre.Material] conc_mat: Material to
         associate with the concrete
     :param Optional[sectionproperties.pre.pre.Material] steel_mat: Material to
@@ -237,6 +239,8 @@ def concrete_column_section(
         xy = np.meshgrid(b_edge_bars_x, d_edge_bars_y)
         all_bar_coords = np.append(xy[0].reshape(-1, 1), xy[1].reshape(-1, 1), axis=1)
 
+    if bar_area is None:
+        bar_area = np.pi * dia_bar**2 / 4
     for bar_coord in all_bar_coords:
         concrete_geometry = add_bar(
             concrete_geometry,

--- a/sectionproperties/pre/library/concrete_sections.py
+++ b/sectionproperties/pre/library/concrete_sections.py
@@ -167,7 +167,7 @@ def concrete_column_section(
         number of points used in the circle. Useful for making the reinforcing bars look
         more circular when plotting the concrete section.
 
-    :raises ValueErorr: If the number of bars in either 'n_bars_b' or 'n_bars_d' is not greater
+    :raises ValueError: If the number of bars in either 'n_bars_b' or 'n_bars_d' is not greater
         than or equal to 2.
 
     The following example creates a 600D x 300W concrete column with 25 mm diameter

--- a/sectionproperties/pre/library/concrete_sections.py
+++ b/sectionproperties/pre/library/concrete_sections.py
@@ -145,8 +145,8 @@ def concrete_column_section(
 ) -> geometry.CompoundGeometry:
     """Constructs a concrete rectangular section of width *b* and depth *d*, with
     steel bar reinforcing organized as an *n_bars_b* by *n_bars_d* array, discretised 
-    with *n_circle* points with equal side and top/bottom
-    *cover* to the steel.
+    with *n_circle* points with equal sides and top/bottom *cover* to the steel which
+    is taken as the clear cover (edge of bar to edge of concrete).
 
     :param float b: Concrete section width, parallel to the x-axis
     :param float d: Concrete section depth, parallel to the y-axis
@@ -170,10 +170,11 @@ def concrete_column_section(
     :raises ValueErorr: If the number of bars in either 'n_bars_b' or 'n_bars_d' is not greater 
         than or equal to 2.
 
-    The following example creates a 600D x 300W concrete beam with 3N20 bottom steel
-    reinforcing bars and 30 mm cover::
+    The following example creates a 600D x 300W concrete column with 25 mm diameter
+    reinforcing bars each with 500 mm**2 area and 35 mm cover in a 3x6 array without
+    the interior bars being filled::
 
-        from sectionproperties.pre.library.concrete_sections import concrete_rectangular_section
+        from sectionproperties.pre.library.concrete_sections import concrete_column_section
         from sectionproperties.pre.pre import Material
 
         concrete = Material(
@@ -186,8 +187,8 @@ def concrete_column_section(
         )
 
         geometry = concrete_column_section(
-            b=300, d=600, bar_diam=dia_top=20, n_top=0, dia_bot=20, n_bot=3, n_circle=24, cover=30,
-            conc_mat=concrete, steel_mat=steel
+            b=300, d=600, dia_bar=25, bar_area=500, cover=35, n_bars_b=3, n_bars_d=6, 
+            conc_mat=concrete, steel_mat=steel, filled=False, n_circle=4
         )
         geometry.create_mesh(mesh_sizes=[500])
 
@@ -226,7 +227,11 @@ def concrete_column_section(
         all_bar_coords = list(set(b_edge_bars_top + b_edge_bars_bottom + d_edge_bars_right + d_edge_bars_left))
     if filled:
         xy = np.meshgrid(b_edge_bars_x, d_edge_bars_y)
-        all_bar_coords = np.append(xy[0].reshape(-1,1),xy[1].reshape(-1,1),axis=1)
+        all_bar_coords = np.append(
+            xy[0].reshape(-1,1), 
+            xy[1].reshape(-1,1),
+            axis=1
+        )
         
     for bar_coord in all_bar_coords:
         concrete_geometry = add_bar(
@@ -237,6 +242,7 @@ def concrete_column_section(
             y=bar_coord[1], 
             n=n_circle
         )
+    return concrete_geometry
 
 
 def concrete_tee_section(

--- a/sectionproperties/pre/library/concrete_sections.py
+++ b/sectionproperties/pre/library/concrete_sections.py
@@ -92,39 +92,30 @@ def concrete_rectangular_section(
     x_i_bot = cover + dia_bot / 2
     spacing_top = (b - 2 * cover - dia_top) / (n_top - 1)
     spacing_bot = (b - 2 * cover - dia_bot) / (n_bot - 1)
+    
+    if area_top is None:
+        area_top = np.pi * dia_top**2 / 4
+    if area_bottom is None:
+        area_bottom = np.pi * dia_bot**2 / 4
 
     # add top bars
     for i in range(n_top):
-        if area_top:
-            bar = primitive_sections.circular_section_by_area(
-                area=area_top, n=n_circle, material=steel_mat
-            )
-        else:
-            bar = primitive_sections.circular_section(
-                d=dia_top, n=n_circle, material=steel_mat
-            )
-
+        bar = primitive_sections.circular_section_by_area(
+            area=area_top, n=n_circle, material=steel_mat
+        )
         bar = bar.shift_section(
             x_offset=x_i_top + spacing_top * i, y_offset=d - cover - dia_top / 2
         )
-
         geom = (geom - bar) + bar
 
     # add bot bars
     for i in range(n_bot):
-        if area_bot:
-            bar = primitive_sections.circular_section_by_area(
-                area=area_bot, n=n_circle, material=steel_mat
-            )
-        else:
-            bar = primitive_sections.circular_section(
-                d=dia_bot, n=n_circle, material=steel_mat
-            )
-
+        bar = primitive_sections.circular_section_by_area(
+            area=area_bot, n=n_circle, material=steel_mat
+        )
         bar = bar.shift_section(
             x_offset=x_i_bot + spacing_bot * i, y_offset=cover + dia_bot / 2
         )
-
         geom = (geom - bar) + bar
 
     return geom
@@ -346,16 +337,16 @@ def concrete_tee_section(
     spacing_top = (b_f - 2 * cover - dia_top) / (n_top - 1)
     spacing_bot = (b - 2 * cover - dia_bot) / (n_bot - 1)
 
+    if area_top is None:
+        area_top = np.pi * dia_top**2 / 4
+    if area_bot is None:
+        area_bot = np.pi * dia_bot**2 / 4
+
     # add top bars
     for i in range(n_top):
-        if area_top:
-            bar = primitive_sections.circular_section_by_area(
-                area=area_top, n=n_circle, material=steel_mat
-            )
-        else:
-            bar = primitive_sections.circular_section(
-                d=dia_top, n=n_circle, material=steel_mat
-            )
+        bar = primitive_sections.circular_section_by_area(
+            area=area_top, n=n_circle, material=steel_mat
+        )
 
         bar = bar.shift_section(
             x_offset=x_i_top + spacing_top * i, y_offset=d - cover - dia_top / 2
@@ -365,14 +356,9 @@ def concrete_tee_section(
 
     # add bot bars
     for i in range(n_bot):
-        if area_bot:
-            bar = primitive_sections.circular_section_by_area(
-                area=area_bot, n=n_circle, material=steel_mat
-            )
-        else:
-            bar = primitive_sections.circular_section(
-                d=dia_bot, n=n_circle, material=steel_mat
-            )
+        bar = primitive_sections.circular_section(
+            d=dia_bot, n=n_circle, material=steel_mat
+        )
 
         bar = bar.shift_section(
             x_offset=x_i_bot + spacing_bot * i, y_offset=cover + dia_bot / 2
@@ -465,20 +451,15 @@ def concrete_circular_section(
     r = d / 2 - cover - dia / 2
     d_theta = 2 * np.pi / n_bar
 
+    if area_bar is None:
+        area_bar = np.pi * dia**2 / 4
     for i in range(n_bar):
-        if area_bar:
-            bar = primitive_sections.circular_section_by_area(
-                area=area_bar, n=n_circle, material=steel_mat
-            )
-        else:
-            bar = primitive_sections.circular_section(
-                d=dia, n=n_circle, material=steel_mat
-            )
-
+        bar = primitive_sections.circular_section_by_area(
+            area=area_bar, n=n_circle, material=steel_mat
+        )
         bar = bar.shift_section(
             x_offset=r * np.cos(i * d_theta), y_offset=r * np.sin(i * d_theta)
         )
-
         geom = (geom - bar) + bar
 
     return geom

--- a/sectionproperties/pre/library/concrete_sections.py
+++ b/sectionproperties/pre/library/concrete_sections.py
@@ -92,11 +92,11 @@ def concrete_rectangular_section(
     x_i_bot = cover + dia_bot / 2
     spacing_top = (b - 2 * cover - dia_top) / (n_top - 1)
     spacing_bot = (b - 2 * cover - dia_bot) / (n_bot - 1)
-    
+
     if area_top is None:
         area_top = np.pi * dia_top**2 / 4
-    if area_bottom is None:
-        area_bottom = np.pi * dia_bot**2 / 4
+    if area_bot is None:
+        area_bot = np.pi * dia_bot**2 / 4
 
     # add top bars
     for i in range(n_top):
@@ -347,23 +347,19 @@ def concrete_tee_section(
         bar = primitive_sections.circular_section_by_area(
             area=area_top, n=n_circle, material=steel_mat
         )
-
         bar = bar.shift_section(
             x_offset=x_i_top + spacing_top * i, y_offset=d - cover - dia_top / 2
         )
-
         geom = (geom - bar) + bar
 
     # add bot bars
     for i in range(n_bot):
-        bar = primitive_sections.circular_section(
-            d=dia_bot, n=n_circle, material=steel_mat
+        bar = primitive_sections.circular_section_by_area(
+            area=area_bot, n=n_circle, material=steel_mat
         )
-
         bar = bar.shift_section(
             x_offset=x_i_bot + spacing_bot * i, y_offset=cover + dia_bot / 2
         )
-
         geom = (geom - bar) + bar
 
     return geom

--- a/sectionproperties/pre/library/concrete_sections.py
+++ b/sectionproperties/pre/library/concrete_sections.py
@@ -131,8 +131,8 @@ def concrete_rectangular_section(
 
 
 def concrete_column_section(
-    b: float, 
-    d: float, 
+    b: float,
+    d: float,
     dia_bar: float,
     bar_area: float,
     cover: float,
@@ -144,7 +144,7 @@ def concrete_column_section(
     n_circle: int = 4,
 ) -> geometry.CompoundGeometry:
     """Constructs a concrete rectangular section of width *b* and depth *d*, with
-    steel bar reinforcing organized as an *n_bars_b* by *n_bars_d* array, discretised 
+    steel bar reinforcing organized as an *n_bars_b* by *n_bars_d* array, discretised
     with *n_circle* points with equal sides and top/bottom *cover* to the steel which
     is taken as the clear cover (edge of bar to edge of concrete).
 
@@ -160,14 +160,14 @@ def concrete_column_section(
     :param Optional[sectionproperties.pre.pre.Material] steel_mat: Material to
         associate with the reinforcing steel
     :param bool filled: When True, will populate the concrete section with an equally
-        spaced 2D array of reinforcing bars numbering 'n_bars_b' by 'n_bars_d'. 
+        spaced 2D array of reinforcing bars numbering 'n_bars_b' by 'n_bars_d'.
         When False, only the bars around the perimeter of the array will be present.
     :param int n_circle: The number of points used to discretize the circle of the reinforcing
         bars. The bars themselves will have an exact area of 'bar_area' regardless of the
         number of points used in the circle. Useful for making the reinforcing bars look
         more circular when plotting the concrete section.
 
-    :raises ValueErorr: If the number of bars in either 'n_bars_b' or 'n_bars_d' is not greater 
+    :raises ValueErorr: If the number of bars in either 'n_bars_b' or 'n_bars_d' is not greater
         than or equal to 2.
 
     The following example creates a 600D x 300W concrete column with 25 mm diameter
@@ -187,7 +187,7 @@ def concrete_column_section(
         )
 
         geometry = concrete_column_section(
-            b=300, d=600, dia_bar=25, bar_area=500, cover=35, n_bars_b=3, n_bars_d=6, 
+            b=300, d=600, dia_bar=25, bar_area=500, cover=35, n_bars_b=3, n_bars_d=6,
             conc_mat=concrete, steel_mat=steel, filled=False, n_circle=4
         )
         geometry.create_mesh(mesh_sizes=[500])
@@ -205,16 +205,17 @@ def concrete_column_section(
         Mesh generated from the above geometry.
     """
     concrete_geometry = primitive_sections.rectangular_section(b, d, material=conc_mat)
-    bar_extents = concrete_geometry.offset_perimeter(-cover - dia_bar/2).calculate_extents()
+    bar_extents = concrete_geometry.offset_perimeter(
+        -cover - dia_bar / 2
+    ).calculate_extents()
     bar_x_min, bar_x_max, bar_y_min, bar_y_max = bar_extents
-    
+
     b_edge_bars_x = np.linspace(bar_x_min, bar_x_max, n_bars_b)
     d_edge_bars_y = np.linspace(bar_y_min, bar_y_max, n_bars_d)
-    
+
     if not filled:
         b_edge_bars_y1 = [bar_y_min] * n_bars_b
         b_edge_bars_y2 = [bar_y_max] * n_bars_b
-
 
         d_edge_bars_x1 = [bar_x_min] * n_bars_d
         d_edge_bars_x2 = [bar_x_max] * n_bars_d
@@ -224,23 +225,26 @@ def concrete_column_section(
         d_edge_bars_right = list(zip(d_edge_bars_x2, d_edge_bars_y))
         d_edge_bars_left = list(zip(d_edge_bars_x1, d_edge_bars_y))
 
-        all_bar_coords = list(set(b_edge_bars_top + b_edge_bars_bottom + d_edge_bars_right + d_edge_bars_left))
+        all_bar_coords = list(
+            set(
+                b_edge_bars_top
+                + b_edge_bars_bottom
+                + d_edge_bars_right
+                + d_edge_bars_left
+            )
+        )
     if filled:
         xy = np.meshgrid(b_edge_bars_x, d_edge_bars_y)
-        all_bar_coords = np.append(
-            xy[0].reshape(-1,1), 
-            xy[1].reshape(-1,1),
-            axis=1
-        )
-        
+        all_bar_coords = np.append(xy[0].reshape(-1, 1), xy[1].reshape(-1, 1), axis=1)
+
     for bar_coord in all_bar_coords:
         concrete_geometry = add_bar(
-            concrete_geometry, 
-            area=bar_area, 
-            material=steel_mat, 
-            x=bar_coord[0], 
-            y=bar_coord[1], 
-            n=n_circle
+            concrete_geometry,
+            area=bar_area,
+            material=steel_mat,
+            x=bar_coord[0],
+            y=bar_coord[1],
+            n=n_circle,
         )
     return concrete_geometry
 

--- a/sectionproperties/tests/test_concrete_sections.py
+++ b/sectionproperties/tests/test_concrete_sections.py
@@ -141,21 +141,38 @@ def test_concrete_circular_section():
 def test_concrete_column_section():
 
     concrete = pre.Material(
-        name='Concrete', elastic_modulus=30.1e3, poissons_ratio=0.2, yield_strength=32,
-        density=2.4e-6, color='lightgrey'
+        name="Concrete",
+        elastic_modulus=30.1e3,
+        poissons_ratio=0.2,
+        yield_strength=32,
+        density=2.4e-6,
+        color="lightgrey",
     )
     steel = pre.Material(
-        name='Steel', elastic_modulus=200e3, poissons_ratio=0.3, yield_strength=500,
-        density=7.85e-6, color='grey'
+        name="Steel",
+        elastic_modulus=200e3,
+        poissons_ratio=0.3,
+        yield_strength=500,
+        density=7.85e-6,
+        color="grey",
     )
 
     geometry = cs.concrete_column_section(
-        b=300, d=600, dia_bar=40, bar_area=500, cover=40, n_bars_b=3, n_bars_d=6, 
-        conc_mat=concrete, steel_mat=steel, filled=False, n_circle=4
-    ) # NOTE: Bar diam and Bar area do not match. This is intentional.
+        b=300,
+        d=600,
+        dia_bar=40,
+        bar_area=500,
+        cover=40,
+        n_bars_b=3,
+        n_bars_d=6,
+        conc_mat=concrete,
+        steel_mat=steel,
+        filled=False,
+        n_circle=4,
+    )  # NOTE: Bar diam and Bar area do not match. This is intentional.
     geometry.create_mesh(mesh_sizes=[500])
 
-        # check geometry is created correctly
+    # check geometry is created correctly
     conc_area = 0
     steel_area = 0
 
@@ -170,24 +187,25 @@ def test_concrete_column_section():
             )
 
     net_area = 300 * 600
-    actual_steel_area = 14 * 500.   
-    
+    actual_steel_area = 14 * 500.0
+
     check.almost_equal(conc_area, net_area - actual_steel_area, rel=r_tol)
     check.almost_equal(steel_area, actual_steel_area, rel=r_tol)
 
     bar_centroids = [tuple(geom.geom.centroid.coords[0]) for geom in geometry.geoms[1:]]
 
     from collections import Counter
+
     x_coords = Counter(round(coord[0], 0) for coord in bar_centroids)
     y_coords = Counter(round(coord[1], 0) for coord in bar_centroids)
 
     # Validate that we have 14 bars with the correct x-coordinates
-    check.equal(x_coords.get(60) , 6)
+    check.equal(x_coords.get(60), 6)
     check.equal(x_coords.get(150), 2)
     check.equal(x_coords.get(240), 6)
 
     # Validate that we have 14 bars with the correct y-coordinates
-    check.equal(y_coords.get(60) , 3)
+    check.equal(y_coords.get(60), 3)
     check.equal(y_coords.get(156), 2)
     check.equal(y_coords.get(252), 2)
     check.equal(y_coords.get(348), 2)
@@ -198,15 +216,19 @@ def test_concrete_column_section():
 def test_add_bar():
     rect = ps.rectangular_section(b=400, d=600)
     steel = pre.Material(
-        name='Steel', elastic_modulus=200e3, poissons_ratio=0.3, yield_strength=500,
-        density=7.85e-6, color='grey'
+        name="Steel",
+        elastic_modulus=200e3,
+        poissons_ratio=0.3,
+        yield_strength=500,
+        density=7.85e-6,
+        color="grey",
     )
     rect = cs.add_bar(rect, area=500, x=100, y=100, material=steel)
     rect = cs.add_bar(rect, area=500, x=200, y=200, material=steel)
     rect_area = rect.geoms[0].geom.area
-    steel_area = 2 * 500.
-    check.almost_equal(rect_area, 400*600 - steel_area)
-    
+    steel_area = 2 * 500.0
+    check.almost_equal(rect_area, 400 * 600 - steel_area)
+
     bar_1 = rect.geoms[1]
     bar_2 = rect.geoms[2]
     check.almost_equal(bar_1.calculate_centroid(), (100, 100))

--- a/sectionproperties/tests/test_concrete_sections.py
+++ b/sectionproperties/tests/test_concrete_sections.py
@@ -2,6 +2,7 @@ import pytest_check as check
 import numpy as np
 import sectionproperties.pre.pre as pre
 import sectionproperties.pre.library.concrete_sections as cs
+import sectionproperties.pre.library.primitive_sections as ps
 
 r_tol = 1e-6
 conc_mat = pre.Material(
@@ -135,3 +136,78 @@ def test_concrete_circular_section():
     # check areas
     check.almost_equal(conc_area, net_area - actual_steel_area, rel=r_tol)
     check.almost_equal(steel_area, actual_steel_area, rel=r_tol)
+
+
+def test_concrete_column_section():
+
+    concrete = pre.Material(
+        name='Concrete', elastic_modulus=30.1e3, poissons_ratio=0.2, yield_strength=32,
+        density=2.4e-6, color='lightgrey'
+    )
+    steel = pre.Material(
+        name='Steel', elastic_modulus=200e3, poissons_ratio=0.3, yield_strength=500,
+        density=7.85e-6, color='grey'
+    )
+
+    geometry = cs.concrete_column_section(
+        b=300, d=600, dia_bar=40, bar_area=500, cover=40, n_bars_b=3, n_bars_d=6, 
+        conc_mat=concrete, steel_mat=steel, filled=False, n_circle=4
+    ) # NOTE: Bar diam and Bar area do not match. This is intentional.
+    geometry.create_mesh(mesh_sizes=[500])
+
+        # check geometry is created correctly
+    conc_area = 0
+    steel_area = 0
+
+    for geom in geometry.geoms:
+        if geom.material == concrete:
+            conc_area += geom.calculate_area()
+        elif geom.material == steel:
+            steel_area += geom.calculate_area()
+        else:
+            raise ValueError(
+                "Material {0} is not correctly assigned".format(geom.material)
+            )
+
+    net_area = 300 * 600
+    actual_steel_area = 14 * 500.   
+    
+    check.almost_equal(conc_area, net_area - actual_steel_area, rel=r_tol)
+    check.almost_equal(steel_area, actual_steel_area, rel=r_tol)
+
+    bar_centroids = [tuple(geom.geom.centroid.coords[0]) for geom in geometry.geoms[1:]]
+
+    from collections import Counter
+    x_coords = Counter(round(coord[0], 0) for coord in bar_centroids)
+    y_coords = Counter(round(coord[1], 0) for coord in bar_centroids)
+
+    # Validate that we have 14 bars with the correct x-coordinates
+    check.equal(x_coords.get(60) , 6)
+    check.equal(x_coords.get(150), 2)
+    check.equal(x_coords.get(240), 6)
+
+    # Validate that we have 14 bars with the correct y-coordinates
+    check.equal(y_coords.get(60) , 3)
+    check.equal(y_coords.get(156), 2)
+    check.equal(y_coords.get(252), 2)
+    check.equal(y_coords.get(348), 2)
+    check.equal(y_coords.get(444), 2)
+    check.equal(y_coords.get(540), 3)
+
+
+def test_add_bar():
+    rect = ps.rectangular_section(b=400, d=600)
+    steel = pre.Material(
+        name='Steel', elastic_modulus=200e3, poissons_ratio=0.3, yield_strength=500,
+        density=7.85e-6, color='grey'
+    )
+    rect = cs.add_bar(rect, area=500, x=100, y=100, material=steel)
+    rect = cs.add_bar(rect, area=500, x=200, y=200, material=steel)
+    rect_area = rect.geoms[0].geom.area
+    steel_area = 2 * 500.
+    check.almost_equal(rect_area, 400*600 - steel_area)
+    
+    bar_1 = rect.geoms[1]
+    bar_2 = rect.geoms[2]
+    check.almost_equal(bar_1.calculate_centroid(), (100, 100))
+    check.almost_equal(bar_2.calculate_centroid(), (200, 200))


### PR DESCRIPTION
This PR adds two new geometry generating functions to the `concrete_sections` module:
1. `concrete_column_section`
2. `add_bar` - Previously only in `concreteproperties`

As I have been working with creating concrete sections, I found a need for including the incredibly useful `add_bar` function into `sectionproperties`. I find that it is a general-purpose function that can be utilized whenever you are reading bar locations from an external data source (e.g. a text file). It allows you to treat your concrete section as an accumulator and for bars to easily be added in a loop.

Additionally, I think it would be useful to include a function for creating a rectangular concrete section with a regular bar array where all bars are the same size and diameter. I called this function `concrete_column_section` to differentiate it from `concrete_rectangular_section` since the orientation of the bars in such arrays would be most like those used in typical concrete columns.

I am open to changing the name of `concrete_column_section` but am submitting it for review and consideration.