### PR TITLE
Unit test stress at point

### DIFF
--- a/sectionproperties/tests/test_stress.py
+++ b/sectionproperties/tests/test_stress.py
@@ -67,6 +67,11 @@ def test_rotated_rectangle():
     b = 50
     d = 100
     angle = math.atan(100 / 50)
+    cx = b / 2 * math.cos(angle) - d / 2 * math.sin(angle)
+    cy = b / 2 * math.sin(angle) + d / 2 * math.cos(angle)
+    Sy = b * d / 6.0 * cy
+    Mxx = 7
+    sig_max = Mxx / Sy
     rot_rect = (
         primitive_sections.rectangular_section(b=b, d=d)
         .shift_section(-b / 2, -d / 2)
@@ -76,10 +81,5 @@ def test_rotated_rectangle():
     rot_sec = Section(rot_rect)
     rot_sec.calculate_geometric_properties()
     rot_sec.calculate_warping_properties()
-    Mxx = 7
-    cx = b / 2 * math.cos(angle) - d / 2 * math.sin(angle)
-    cy = b / 2 * math.sin(angle) + d / 2 * math.cos(angle)
-    Sy = b * d / 6.0 * cy
-    sig_max = Mxx / Sy
     (sig_0, sig_1) = rot_sec.get_stress_at_points(pts=[[cx, 0], [cx, cy]], Mxx=Mxx)
     assert sig_1 == pytest.approx((sig_max, 0, 0))

--- a/sectionproperties/tests/test_stress.py
+++ b/sectionproperties/tests/test_stress.py
@@ -1,4 +1,5 @@
 import pytest
+import math
 import sectionproperties.pre.library.primitive_sections as primitive_sections
 from sectionproperties.analysis.section import Section
 
@@ -48,3 +49,37 @@ def test_stress_runtime_errors():
     sec.calculate_stress(Vy=1)
     sec.calculate_stress(Mzz=1)
     sec.get_stress_at_points(pts=[[10, 10]], Mzz=1)
+
+
+def test_rectangle():
+    Mxx = 7
+    Sy = 50.0 * 100.0**2 / 6.0
+    sig_max = Mxx / Sy
+    (sig_0, sig_1, sig_2) = sec.get_stress_at_points(
+        pts=[[25, 50], [25, 75], [25, 100]], Mxx=Mxx
+    )
+    assert sig_0 == pytest.approx((0, 0, 0))
+    assert sig_1 == pytest.approx((sig_max / 2.0, 0, 0))
+    assert sig_2 == pytest.approx((sig_max, 0, 0))
+
+
+def test_rotated_rectangle():
+    b = 50
+    d = 100
+    angle = math.atan(100 / 50)
+    rot_rect = (
+        primitive_sections.rectangular_section(b=b, d=d)
+        .shift_section(-b / 2, -d / 2)
+        .rotate_section(angle, use_radians=True)
+    )
+    rot_rect.create_mesh(mesh_sizes=0)  # coarse mesh
+    rot_sec = Section(rot_rect)
+    rot_sec.calculate_geometric_properties()
+    rot_sec.calculate_warping_properties()
+    Mxx = 7
+    cx = b / 2 * math.cos(angle) - d / 2 * math.sin(angle)
+    cy = b / 2 * math.sin(angle) + d / 2 * math.cos(angle)
+    Sy = b * d / 6.0 * cy
+    sig_max = Mxx / Sy
+    (sig_0, sig_1) = rot_sec.get_stress_at_points(pts=[[cx, 0], [cx, cy]], Mxx=Mxx)
+    assert sig_1 == pytest.approx((sig_max, 0, 0))


### PR DESCRIPTION
These tests are intended to extend the testing of the get_stress_at_points functionality. They are based on the following simple cases: 

- rectangular section with a mxx applied
- rotated rectangular section such that mxx is applied about the diagonal