### PR TITLE
Allow unlipped cee and zed steel_sections

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog:
 ==========
 
+v2.1.5:
+-------
+
+- Fix shapely 2.0 imports and STRtree implementation, with thanks to `@normanrichardson <https://github.com/normanrichardson>`_
+- Add support for python 3.10, drop support for python 3.7
+
+**Full changelog:** `2.1.4...2.1.5 <https://github.com/robbievanleeuwen/section-properties/compare/2.1.4...2.1.5>`_
+
 v2.1.4:
 -------
 

--- a/sectionproperties/__init__.py
+++ b/sectionproperties/__init__.py
@@ -6,4 +6,4 @@ sectionproperties can be used to determine section properties to be used
 in structural design and visualise cross-sectional stresses resulting
 from combinations of applied forces and bending moments.
 """
-__version__ = "2.1.4"
+__version__ = "2.1.5"

--- a/sectionproperties/pre/library/steel_sections.py
+++ b/sectionproperties/pre/library/steel_sections.py
@@ -1030,7 +1030,7 @@ def cee_section(
 
     :param float d: Depth of the Cee section
     :param float b: Width of the Cee section
-    :param float l: Lip of the Cee section
+    :param float l: Lip of the Cee section (which can be zero)
     :param float t: Thickness of the Cee section
     :param float r_out: Outer radius of the Cee section
     :param int n_r: Number of points discretising the outer radius
@@ -1056,10 +1056,6 @@ def cee_section(
         :align: center
         :scale: 75 %
     """
-    # ensure the lip length is greater than the outer radius
-    if l < r_out:
-        raise Exception("Lip length must be greater than the outer radius")
-
     points = []
 
     # calculate internal radius
@@ -1068,16 +1064,31 @@ def cee_section(
     # construct the outer bottom left radius
     points += draw_radius([r_out, r_out], r_out, np.pi, n_r)
 
-    # construct the outer bottom right radius
-    points += draw_radius([b - r_out, r_out], r_out, 1.5 * np.pi, n_r)
+    # if the lip is longer than the outer radius (curve + straight section
+    if l > r_out:
+        # construct the outer bottom right radius
+        points += draw_radius([b - r_out, r_out], r_out, 1.5 * np.pi, n_r)
 
-    if r_out != l:
         # add next two points
         points.append([b, l])
         points.append([b - t, l])
 
-    # construct the inner bottom right radius
-    points += draw_radius([b - t - r_in, t + r_in], r_in, 0, n_r, False)
+        # construct the inner bottom right radius
+        points += draw_radius([b - t - r_in, t + r_in], r_in, 0, n_r, False)
+    
+    # if the lip is shorter than the outer radius (curve only)
+    elif t < l and l <= r_out:
+        # construct a smaller corner for bottom right if t < l < r_out
+        r_out_l = l
+        r_in_l = max(l - t, 0)
+        points += draw_radius([b - r_out_l, r_out_l], r_out_l, 1.5 * np.pi, n_r)
+        points += draw_radius([b - t - r_in_l, t + r_in_l], r_in_l, 0, n_r, False)
+
+    # if the lip length is less than the section thickness (no lip)
+    elif l <= t:
+        # construct end as two points only
+        points.append([b, 0])
+        points.append([b, t])
 
     # construct the inner bottom left radius
     points += draw_radius([t + r_in, t + r_in], r_in, 1.5 * np.pi, n_r, False)
@@ -1085,16 +1096,33 @@ def cee_section(
     # construct the inner top left radius
     points += draw_radius([t + r_in, d - t - r_in], r_in, np.pi, n_r, False)
 
-    # construct the inner top right radius
-    points += draw_radius([b - t - r_in, d - t - r_in], r_in, 0.5 * np.pi, n_r, False)
+    # if the lip is longer than the outer radius (curve + straight section)
+    if l > r_out:
+        # construct the inner top right radius
+        points += draw_radius(
+            [b - t - r_in, d - t - r_in], r_in, 0.5 * np.pi, n_r, False
+        )
 
-    if r_out != l:
         # add next two points
         points.append([b - t, d - l])
         points.append([b, d - l])
 
-    # construct the outer top right radius
-    points += draw_radius([b - r_out, d - r_out], r_out, 0, n_r)
+        # construct the outer top right radius
+        points += draw_radius([b - r_out, d - r_out], r_out, 0, n_r)
+
+    # if the lip is shorter than the outer radius (curve only)
+    elif l > t and l <= r_out:
+        # construct a smaller corner for top right if t < l < r_out
+        points += draw_radius(
+            [b - t - r_in_l, d - t - r_in_l], r_in_l, 0.5 * np.pi, n_r, False
+        )
+        points += draw_radius([b - r_out_l, d - r_out_l], r_out_l, 0, n_r)
+
+    # if the lip length is less than the section thickness (no lip)
+    elif l <= t:
+        # construct end as two points only
+        points.append([b, d - t])
+        points.append([b, d])
 
     # construct the outer top left radius
     points += draw_radius([r_out, d - r_out], r_out, 0.5 * np.pi, n_r)
@@ -1121,7 +1149,7 @@ def zed_section(
     :param float d: Depth of the zed section
     :param float b_l: Left flange width of the Zed section
     :param float b_r: Right flange width of the Zed section
-    :param float l: Lip of the Zed section
+    :param float l: Lip of the Zed section (which can be zero)
     :param float t: Thickness of the Zed section
     :param float r_out: Outer radius of the Zed section
     :param int n_r: Number of points discretising the outer radius
@@ -1146,10 +1174,6 @@ def zed_section(
         :align: center
         :scale: 75 %
     """
-    # ensure the lip length is greater than the outer radius
-    if l < r_out:
-        raise Exception("Lip length must be greater than the outer radius")
-
     points = []
 
     # calculate internal radius
@@ -1158,16 +1182,31 @@ def zed_section(
     # construct the outer bottom left radius
     points += draw_radius([r_out, r_out], r_out, np.pi, n_r)
 
-    # construct the outer bottom right radius
-    points += draw_radius([b_r - r_out, r_out], r_out, 1.5 * np.pi, n_r)
+    # if the lip is longer than the outer radius (curve + straight section
+    if l > r_out:
+        # construct the outer bottom right radius
+        points += draw_radius([b_r - r_out, r_out], r_out, 1.5 * np.pi, n_r)
 
-    if r_out != l:
         # add next two points
         points.append([b_r, l])
         points.append([b_r - t, l])
 
-    # construct the inner bottom right radius
-    points += draw_radius([b_r - t - r_in, t + r_in], r_in, 0, n_r, False)
+        # construct the inner bottom right radius
+        points += draw_radius([b_r - t - r_in, t + r_in], r_in, 0, n_r, False)
+    
+    # if the lip is shorter than the outer radius (curve only)
+    elif l > t and l <= r_out:
+        # construct a smaller corner for bottom right if t < l < r_out
+        r_out_l = l
+        r_in_l = max(l - t, 0)
+        points += draw_radius([b_r - r_out_l, r_out_l], r_out_l, 1.5 * np.pi, n_r)
+        points += draw_radius([b_r - t - r_in_l, t + r_in_l], r_in_l, 0, n_r, False)
+    
+    # if the lip length is less than the section thickness (no lip)
+    elif l <= t:
+        # construct end as two points only
+        points.append([b_r, 0])
+        points.append([b_r, t])
 
     # construct the inner bottom left radius
     points += draw_radius([t + r_in, t + r_in], r_in, 1.5 * np.pi, n_r, False)
@@ -1175,16 +1214,35 @@ def zed_section(
     # construct the outer top right radius
     points += draw_radius([t - r_out, d - r_out], r_out, 0, n_r)
 
-    # construct the outer top left radius
-    points += draw_radius([t - b_l + r_out, d - r_out], r_out, 0.5 * np.pi, n_r)
+    # if the lip is longer than the outer radius (curve + straight section
+    if l > r_out:
+        # construct the outer top left radius
+        points += draw_radius([t - b_l + r_out, d - r_out], r_out, 0.5 * np.pi, n_r)
 
-    if r_out != l:
         # add the next two points
         points.append([t - b_l, d - l])
         points.append([t - b_l + t, d - l])
 
-    # construct the inner top left radius
-    points += draw_radius([2 * t - b_l + r_in, d - t - r_in], r_in, np.pi, n_r, False)
+        # construct the inner top left radius
+        points += draw_radius(
+            [2 * t - b_l + r_in, d - t - r_in], r_in, np.pi, n_r, False
+        )
+
+    # if the lip is shorter than the outer radius (curve only)
+    elif t < l and l <= r_out:
+        # construct a smaller corner for top left if t < l < r_out
+        points += draw_radius(
+            [t - b_l + r_out_l, d - r_out_l], r_out_l, 0.5 * np.pi, n_r
+        )
+        points += draw_radius(
+            [2 * t - b_l + r_in_l, d - t - r_in_l], r_in_l, np.pi, n_r, False
+        )
+
+    # if the lip length is less than the section thickness (no lip)
+    elif l <= t:
+        # construct end as two points only
+        points.append([t - b_l, d])
+        points.append([t - b_l, d - t])
 
     # construct the inner top right radius
     points += draw_radius([-r_in, d - t - r_in], r_in, 0.5 * np.pi, n_r, False)


### PR DESCRIPTION
Unlipped Cee sections are very common. For example, all track ("T") sections in the Steel Framing Industry Association standard sections, [as defined here](https://sfia.memberclicks.net/assets/TechFiles/sfia%20tech%20spec%202015%20updated%207.12.17.pdf), are unlipped Cee sections. However, `section-properties` currently explicitly throws an error if lip length `l` is set to anything less than `r_out` (the outer radius). 

This pull request adds the ability to set `l` to zero - or anything less than `r_out`. 

Note that I did have a question as to what to do for `0 < l < r_out`. One option would be to throw an error in this case, but I opted instead for decreasing the outer radius commensurately, on the philosophy that fewer error conditions is probably better, but am happy to change this as well. 

While unlipped Zed sections are less common than unlipped Cees, they do exist - and a nearly-identical update could be applied to `zed_section()` to allow unlipped zeds as well here. 