### PR TITLE
Composite results changes

### DIFF
--- a/.github/workflows/constraints.txt
+++ b/.github/workflows/constraints.txt
@@ -1,5 +1,5 @@
 pip==23.1.2
 nox==2023.4.22
-nox-poetry==1.0.2
+nox-poetry==1.0.3
 poetry==1.5.1
 virtualenv==20.23.0

--- a/docs/examples/geometry/section_library.ipynb
+++ b/docs/examples/geometry/section_library.ipynb
@@ -442,9 +442,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ei = sec.get_ic()  # TODO: fix when I change this!\n",
-    "i_eff = ei[0] / concrete.elastic_modulus\n",
-    "print(f\"I_eff = {i_eff:.3e} mm6\")\n",
+    "ei = sec.get_eic(e_ref=concrete)\n",
+    "print(f\"I_eff = {ei[0]:.3e} mm6\")\n",
     "print(f\"I_rec = {(300 * 600**3 / 12):.3e} mm6\")"
    ]
   }

--- a/poetry.lock
+++ b/poetry.lock
@@ -114,6 +114,20 @@ files = [
 python-dateutil = ">=2.7.0"
 
 [[package]]
+name = "async-lru"
+version = "2.0.4"
+description = "Simple LRU cache for asyncio"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "async-lru-2.0.4.tar.gz", hash = "sha256:b8a59a5df60805ff63220b2a0c5b5393da5521b113cd5465a44eb037d81a5627"},
+    {file = "async_lru-2.0.4-py3-none-any.whl", hash = "sha256:ff02944ce3c288c5be660c42dbcca0742b32c3b279d6dceda655190240b99224"},
+]
+
+[package.dependencies]
+typing-extensions = {version = ">=4.0.0", markers = "python_version < \"3.11\""}
+
+[[package]]
 name = "attrs"
 version = "23.1.0"
 description = "Classes Without Boilerplate"
@@ -1121,17 +1135,6 @@ qtconsole = ["qtconsole"]
 test = ["ipykernel", "nbformat", "nose (>=0.10.1)", "numpy (>=1.17)", "pygments", "requests", "testpath"]
 
 [[package]]
-name = "ipython-genutils"
-version = "0.2.0"
-description = "Vestigial utilities from IPython"
-optional = false
-python-versions = "*"
-files = [
-    {file = "ipython_genutils-0.2.0-py2.py3-none-any.whl", hash = "sha256:72dd37233799e619666c9f639a9da83c34013a73e8bbc79a7a6348d93c61fab8"},
-    {file = "ipython_genutils-0.2.0.tar.gz", hash = "sha256:eb2e116e75ecef9d4d228fdc66af54269afa26ab4463042e33785b887c628ba8"},
-]
-
-[[package]]
 name = "ipywidgets"
 version = "8.0.6"
 description = "Jupyter interactive widgets"
@@ -1220,6 +1223,20 @@ MarkupSafe = ">=2.0"
 i18n = ["Babel (>=2.7)"]
 
 [[package]]
+name = "json5"
+version = "0.9.14"
+description = "A Python implementation of the JSON5 data format."
+optional = false
+python-versions = "*"
+files = [
+    {file = "json5-0.9.14-py2.py3-none-any.whl", hash = "sha256:740c7f1b9e584a468dbb2939d8d458db3427f2c93ae2139d05f47e453eae964f"},
+    {file = "json5-0.9.14.tar.gz", hash = "sha256:9ed66c3a6ca3510a976a9ef9b8c0787de24802724ab1860bc0153c7fdd589b02"},
+]
+
+[package.extras]
+dev = ["hypothesis"]
+
+[[package]]
 name = "jsonpointer"
 version = "2.4"
 description = "Identify specific nodes in a JSON document (RFC 6901)"
@@ -1227,6 +1244,7 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*"
 files = [
     {file = "jsonpointer-2.4-py2.py3-none-any.whl", hash = "sha256:15d51bba20eea3165644553647711d150376234112651b4f1811022aecad7d7a"},
+    {file = "jsonpointer-2.4.tar.gz", hash = "sha256:585cee82b70211fa9e6043b7bb89db6e1aa49524340dde8ad6b63206ea689d88"},
 ]
 
 [[package]]
@@ -1326,6 +1344,21 @@ docs = ["jupyterlite-sphinx", "myst-parser", "pydata-sphinx-theme", "sphinxcontr
 test = ["click", "coverage", "pre-commit", "pytest (>=7.0)", "pytest-asyncio (>=0.19.0)", "pytest-console-scripts", "pytest-cov", "rich"]
 
 [[package]]
+name = "jupyter-lsp"
+version = "2.2.0"
+description = "Multi-Language Server WebSocket proxy for Jupyter Notebook/Lab server"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "jupyter-lsp-2.2.0.tar.gz", hash = "sha256:8ebbcb533adb41e5d635eb8fe82956b0aafbf0fd443b6c4bfa906edeeb8635a1"},
+    {file = "jupyter_lsp-2.2.0-py3-none-any.whl", hash = "sha256:9e06b8b4f7dd50300b70dd1a78c0c3b0c3d8fa68e0f2d8a5d1fbab62072aca3f"},
+]
+
+[package.dependencies]
+importlib-metadata = {version = ">=4.8.3", markers = "python_version < \"3.10\""}
+jupyter-server = ">=1.1.2"
+
+[[package]]
 name = "jupyter-server"
 version = "2.6.0"
 description = "The backend—i.e. core services, APIs, and REST endpoints—to Jupyter web applications."
@@ -1381,6 +1414,39 @@ docs = ["jinja2", "jupyter-server", "mistune (<3.0)", "myst-parser", "nbformat",
 test = ["coverage", "jupyter-server (>=2.0.0)", "pytest (>=7.0)", "pytest-cov", "pytest-jupyter[server] (>=0.5.3)", "pytest-timeout"]
 
 [[package]]
+name = "jupyterlab"
+version = "4.0.6"
+description = "JupyterLab computational environment"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "jupyterlab-4.0.6-py3-none-any.whl", hash = "sha256:7d9dacad1e3f30fe4d6d4efc97fda25fbb5012012b8f27cc03a2283abcdee708"},
+    {file = "jupyterlab-4.0.6.tar.gz", hash = "sha256:6c43ae5a6a1fd2fdfafcb3454004958bde6da76331abb44cffc6f9e436b19ba1"},
+]
+
+[package.dependencies]
+async-lru = ">=1.0.0"
+importlib-metadata = {version = ">=4.8.3", markers = "python_version < \"3.10\""}
+importlib-resources = {version = ">=1.4", markers = "python_version < \"3.9\""}
+ipykernel = "*"
+jinja2 = ">=3.0.3"
+jupyter-core = "*"
+jupyter-lsp = ">=2.0.0"
+jupyter-server = ">=2.4.0,<3"
+jupyterlab-server = ">=2.19.0,<3"
+notebook-shim = ">=0.2"
+packaging = "*"
+tomli = {version = "*", markers = "python_version < \"3.11\""}
+tornado = ">=6.2.0"
+traitlets = "*"
+
+[package.extras]
+dev = ["black[jupyter] (==23.7.0)", "build", "bump2version", "coverage", "hatch", "pre-commit", "pytest-cov", "ruff (==0.0.286)"]
+docs = ["jsx-lexer", "myst-parser", "pydata-sphinx-theme (>=0.13.0)", "pytest", "pytest-check-links", "pytest-tornasync", "sphinx (>=1.8,<7.2.0)", "sphinx-copybutton"]
+docs-screenshots = ["altair (==5.0.1)", "ipython (==8.14.0)", "ipywidgets (==8.0.6)", "jupyterlab-geojson (==3.4.0)", "jupyterlab-language-pack-zh-cn (==4.0.post0)", "matplotlib (==3.7.1)", "nbconvert (>=7.0.0)", "pandas (==2.0.2)", "scipy (==1.10.1)", "vega-datasets (==0.9.0)"]
+test = ["coverage", "pytest (>=7.0)", "pytest-check-links (>=0.7)", "pytest-console-scripts", "pytest-cov", "pytest-jupyter (>=0.5.3)", "pytest-timeout", "pytest-tornasync", "requests", "requests-cache", "virtualenv"]
+
+[[package]]
 name = "jupyterlab-pygments"
 version = "0.2.2"
 description = "Pygments theme using JupyterLab CSS variables"
@@ -1390,6 +1456,32 @@ files = [
     {file = "jupyterlab_pygments-0.2.2-py2.py3-none-any.whl", hash = "sha256:2405800db07c9f770863bcf8049a529c3dd4d3e28536638bd7c1c01d2748309f"},
     {file = "jupyterlab_pygments-0.2.2.tar.gz", hash = "sha256:7405d7fde60819d905a9fa8ce89e4cd830e318cdad22a0030f7a901da705585d"},
 ]
+
+[[package]]
+name = "jupyterlab-server"
+version = "2.24.0"
+description = "A set of server components for JupyterLab and JupyterLab like applications."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "jupyterlab_server-2.24.0-py3-none-any.whl", hash = "sha256:5f077e142bb8dc9b843d960f940c513581bceca3793a0d80f9c67d9522c4e876"},
+    {file = "jupyterlab_server-2.24.0.tar.gz", hash = "sha256:4e6f99e0a5579bbbc32e449c4dbb039561d4f1a7827d5733273ed56738f21f07"},
+]
+
+[package.dependencies]
+babel = ">=2.10"
+importlib-metadata = {version = ">=4.8.3", markers = "python_version < \"3.10\""}
+jinja2 = ">=3.0.3"
+json5 = ">=0.9.0"
+jsonschema = ">=4.17.3"
+jupyter-server = ">=1.21,<3"
+packaging = ">=21.3"
+requests = ">=2.28"
+
+[package.extras]
+docs = ["autodoc-traits", "jinja2 (<3.2.0)", "mistune (<4)", "myst-parser", "pydata-sphinx-theme", "sphinx", "sphinx-copybutton", "sphinxcontrib-openapi (>0.8)"]
+openapi = ["openapi-core (>=0.16.1,<0.17.0)", "ruamel-yaml"]
+test = ["hatch", "ipykernel", "jupyterlab-server[openapi]", "openapi-spec-validator (>=0.5.1,<0.7.0)", "pytest (>=7.0)", "pytest-console-scripts", "pytest-cov", "pytest-jupyter[server] (>=0.6.2)", "pytest-timeout", "requests-mock", "sphinxcontrib-spelling", "strict-rfc3339", "werkzeug"]
 
 [[package]]
 name = "jupyterlab-widgets"
@@ -1709,41 +1801,6 @@ files = [
 ]
 
 [[package]]
-name = "nbclassic"
-version = "1.0.0"
-description = "Jupyter Notebook as a Jupyter Server extension."
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "nbclassic-1.0.0-py3-none-any.whl", hash = "sha256:f99e4769b4750076cd4235c044b61232110733322384a94a63791d2e7beacc66"},
-    {file = "nbclassic-1.0.0.tar.gz", hash = "sha256:0ae11eb2319455d805596bf320336cda9554b41d99ab9a3c31bf8180bffa30e3"},
-]
-
-[package.dependencies]
-argon2-cffi = "*"
-ipykernel = "*"
-ipython-genutils = "*"
-jinja2 = "*"
-jupyter-client = ">=6.1.1"
-jupyter-core = ">=4.6.1"
-jupyter-server = ">=1.8"
-nbconvert = ">=5"
-nbformat = "*"
-nest-asyncio = ">=1.5"
-notebook-shim = ">=0.2.3"
-prometheus-client = "*"
-pyzmq = ">=17"
-Send2Trash = ">=1.8.0"
-terminado = ">=0.8.3"
-tornado = ">=6.1"
-traitlets = ">=4.2.1"
-
-[package.extras]
-docs = ["myst-parser", "nbsphinx", "sphinx", "sphinx-rtd-theme", "sphinxcontrib-github-alt"]
-json-logging = ["json-logging"]
-test = ["coverage", "nbval", "pytest", "pytest-cov", "pytest-jupyter", "pytest-playwright", "pytest-tornasync", "requests", "requests-unixsocket", "testpath"]
-
-[[package]]
 name = "nbclient"
 version = "0.8.0"
 description = "A client library for executing notebooks. Formerly nbconvert's ExecutePreprocessor."
@@ -1870,37 +1927,26 @@ setuptools = "*"
 
 [[package]]
 name = "notebook"
-version = "6.5.4"
-description = "A web-based notebook environment for interactive computing"
+version = "7.0.4"
+description = "Jupyter Notebook - A web-based notebook environment for interactive computing"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "notebook-6.5.4-py3-none-any.whl", hash = "sha256:dd17e78aefe64c768737b32bf171c1c766666a21cc79a44d37a1700771cab56f"},
-    {file = "notebook-6.5.4.tar.gz", hash = "sha256:517209568bd47261e2def27a140e97d49070602eea0d226a696f42a7f16c9a4e"},
+    {file = "notebook-7.0.4-py3-none-any.whl", hash = "sha256:ee738414ac01773c1ad6834cf76cc6f1ce140ac8197fd13b3e2d44d89e257f72"},
+    {file = "notebook-7.0.4.tar.gz", hash = "sha256:0c1b458f72ce8774445c8ef9ed2492bd0b9ce9605ac996e2b066114f69795e71"},
 ]
 
 [package.dependencies]
-argon2-cffi = "*"
-ipykernel = "*"
-ipython-genutils = "*"
-jinja2 = "*"
-jupyter-client = ">=5.3.4"
-jupyter-core = ">=4.6.1"
-nbclassic = ">=0.4.7"
-nbconvert = ">=5"
-nbformat = "*"
-nest-asyncio = ">=1.5"
-prometheus-client = "*"
-pyzmq = ">=17"
-Send2Trash = ">=1.8.0"
-terminado = ">=0.8.3"
-tornado = ">=6.1"
-traitlets = ">=4.2.1"
+jupyter-server = ">=2.4.0,<3"
+jupyterlab = ">=4.0.2,<5"
+jupyterlab-server = ">=2.22.1,<3"
+notebook-shim = ">=0.2,<0.3"
+tornado = ">=6.2.0"
 
 [package.extras]
-docs = ["myst-parser", "nbsphinx", "sphinx", "sphinx-rtd-theme", "sphinxcontrib-github-alt"]
-json-logging = ["json-logging"]
-test = ["coverage", "nbval", "pytest", "pytest-cov", "requests", "requests-unixsocket", "selenium (==4.1.5)", "testpath"]
+dev = ["hatch", "pre-commit"]
+docs = ["myst-parser", "nbsphinx", "pydata-sphinx-theme", "sphinx (>=1.3.6)", "sphinxcontrib-github-alt", "sphinxcontrib-spelling"]
+test = ["importlib-resources (>=5.0)", "ipykernel", "jupyter-server[test] (>=2.4.0,<3)", "jupyterlab-server[test] (>=2.22.1,<3)", "nbval", "pytest (>=7.0)", "pytest-console-scripts", "pytest-timeout", "pytest-tornasync", "requests"]
 
 [[package]]
 name = "notebook-shim"
@@ -3549,4 +3595,4 @@ rhino = ["rhino-shapley-interop", "rhino3dm"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<3.11"
-content-hash = "85fe1dd56add25de19da64f55b69625f1c362f0bc1f7b5ca42e0357eb505f041"
+content-hash = "49f2ad3af5b0f5a463ad2010138aca9e98505533369fb5f8cbcecd4f040d6325"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ ipywidgets = "^8.0.6"
 isort = "^5.12.0"
 nbconvert = "==7.4.0"  # 7.5.0 requires pandoc >2.14.2 (not in RTD or ubuntu 22.04)
 nbsphinx = "^0.9.2"
-notebook = "^6.5.4"
+notebook = "^7.0.4"
 pep8-naming = "^0.13.3"
 pre-commit = "^3.3.3"
 pre-commit-hooks = "^4.4.0"

--- a/src/sectionproperties/analysis/section.py
+++ b/src/sectionproperties/analysis/section.py
@@ -1710,23 +1710,21 @@ class Section:
 
     def get_e_ref(
         self,
-        e_trans: float | pre.Material,
+        e_ref: float | pre.Material,
     ) -> float:
-        """Extract transformed elastic modulus from e_trans (float or material).
+        """Extract transformed elastic modulus from e_ref (float or material).
 
         Args:
-            e_trans: Reference elastic modulus or material property by which to
+            e_ref: Reference elastic modulus or material property by which to
                 transform the results
 
         Returns:
             Transformed elastic modulus
         """
-        if isinstance(e_trans, pre.Material):
-            e_ref = e_trans.elastic_modulus
+        if isinstance(e_ref, pre.Material):
+            return e_ref.elastic_modulus
         else:
-            e_ref = e_trans
-
-        return e_ref
+            return e_ref
 
     def get_area(self) -> float:
         """Returns the cross-section area.
@@ -1788,7 +1786,7 @@ class Section:
 
     def get_ea(
         self,
-        e_trans: float | pre.Material = 1,
+        e_ref: float | pre.Material = 1,
     ) -> float:
         """Returns the cross-section axial rigidity.
 
@@ -1799,8 +1797,8 @@ class Section:
         material property.
 
         Args:
-            e_trans: Reference elastic modulus or material property by which to
-                transform the results
+            e_ref: Reference elastic modulus or material property by which to transform
+                the results
 
         Returns:
             Modulus weighted area (axial rigidity)
@@ -1810,12 +1808,13 @@ class Section:
             AssertionError: If a geometric analysis has not been performed
         """
         if not self.is_composite():
-            msg = "Material properties must be applied to calculate a cross-section "
-            msg += "axial rigidity."
+            msg = "Attempting to get a composite only property for a geometric analysis"
+            msg += " (material properties have not been applied). Consider using"
+            msg += " get_area()."
             raise RuntimeError(msg)
 
-        # calculate e_ref (transformed elastic modulus)
-        e_ref = self.get_e_ref(e_trans=e_trans)
+        # obtain e_ref (reference elastic modulus)
+        e_ref = self.get_e_ref(e_ref=e_ref)
 
         try:
             assert self.section_props.ea is not None
@@ -1852,7 +1851,7 @@ class Section:
 
     def get_eq(
         self,
-        e_trans: float | pre.Material = 1,
+        e_ref: float | pre.Material = 1,
     ) -> tuple[float, float]:
         """Returns the modulus-weighted cross-section first moments of area.
 
@@ -1863,8 +1862,8 @@ class Section:
         material property.
 
         Args:
-            e_trans: Reference elastic modulus or material property by which to
-                transform the results
+            e_ref: Reference elastic modulus or material property by which to transform
+                the results
 
         Returns:
             Modulus-weighted first moments of area about the global axis (``eqx``,
@@ -1881,7 +1880,7 @@ class Section:
             raise RuntimeError(msg)
 
         # calculate e_ref (transformed elastic modulus)
-        e_ref = self.get_e_ref(e_trans=e_trans)
+        e_ref = self.get_e_ref(e_ref=e_ref)
 
         try:
             assert self.section_props.qx is not None

--- a/src/sectionproperties/analysis/section.py
+++ b/src/sectionproperties/analysis/section.py
@@ -450,13 +450,20 @@ class Section:
             self.section_props.omega = omega
 
             # determine the torsion constant
-            ixx_c, iyy_c, ixy_c = self.get_ic()
+            if self.is_composite():
+                ixx_c, iyy_c, ixy_c = self.get_eic()
+            else:
+                ixx_c, iyy_c, ixy_c = self.get_ic()
+
             self.section_props.j = (
                 ixx_c + iyy_c - omega.dot(k_lg[:-1, :-1].dot(np.transpose(omega)))
             )  # type: ignore (last line always evaluates to a float due to dims)
 
             # assemble shear function load vectors
-            nu_eff = self.get_nu_eff()
+            if self.is_composite():
+                nu_eff = self.get_nu_eff()
+            else:
+                nu_eff = 0.0
 
             def assemble_shear_load(
                 progress: Progress | None = None,
@@ -632,7 +639,11 @@ class Section:
             self.section_props.y_st = y_st
 
             # calculate warping constant
-            ea = self.get_ea()
+            if self.is_composite():
+                ea = self.get_ea()
+            else:
+                ea = self.get_area()
+
             self.section_props.gamma = (
                 i_omega - q_omega**2 / ea - y_se * i_xomega + x_se * i_yomega
             )
@@ -753,7 +764,11 @@ class Section:
                 int_x, int_y, int_11, int_22 = calculate_monosymmetry_integrals()
 
             # calculate the monosymmetry constants
-            i11_c, i22_c = self.get_ip()
+            if self.is_composite():
+                i11_c, i22_c = self.get_eip()
+            else:
+                i11_c, i22_c = self.get_ip()
+
             self.section_props.beta_x_plus = -int_x / ixx_c + 2 * y_se
             self.section_props.beta_x_minus = int_x / ixx_c - 2 * y_se
             self.section_props.beta_y_plus = -int_y / iyy_c + 2 * x_se
@@ -872,15 +887,25 @@ class Section:
             self.section_props.calculate_elastic_centroid()
 
             # calculate second moments of area about the centroidal xy axis
-            ea = self.get_ea()
-            qx, qy = self.get_q()
-            ixx_g, iyy_g, ixy_g = self.get_ig()
+            if self.is_composite():
+                ea = self.get_ea()
+                qx, qy = self.get_eq()
+                ixx_g, iyy_g, ixy_g = self.get_eig()
+            else:
+                ea = self.get_area()
+                qx, qy = self.get_q()
+                ixx_g, iyy_g, ixy_g = self.get_ig()
+
             self.section_props.ixx_c = ixx_g - qx**2 / ea
             self.section_props.iyy_c = iyy_g - qy**2 / ea
             self.section_props.ixy_c = ixy_g - qx * qy / ea
 
             # calculate the principal axis angle
-            ixx_c, iyy_c, ixy_c = self.get_ic()
+            if self.is_composite():
+                ixx_c, iyy_c, ixy_c = self.get_eic()
+            else:
+                ixx_c, iyy_c, ixy_c = self.get_ic()
+
             delta = (((ixx_c - iyy_c) / 2) ** 2 + ixy_c**2) ** 0.5
 
             i11_c = (ixx_c + iyy_c) / 2 + delta
@@ -1010,7 +1035,11 @@ class Section:
             self.section_props.omega = omega
 
             # determine the torsion constant
-            ixx_c, iyy_c, _ = self.get_ic()
+            if self.is_composite():
+                ixx_c, iyy_c, _ = self.get_eic()
+            else:
+                ixx_c, iyy_c, _ = self.get_ic()
+
             self.section_props.j = (
                 ixx_c + iyy_c - omega.dot(k_lg[:-1, :-1].dot(np.transpose(omega)))
             )  # type: ignore (last line always evaluates to a float due to dims)
@@ -1219,15 +1248,26 @@ class Section:
             stress_post = sp_stress_post.StressPost(section=self)
 
             # get relevant section properties
-            ea = self.get_ea()
             cx, cy = self.get_c()
-            ixx, iyy, ixy = self.get_ic()
-            i11, i22 = self.get_ip()
             phi = self.get_phi()
 
+            if self.is_composite():
+                ea = self.get_ea()
+                ixx, iyy, ixy = self.get_eic()
+                i11, i22 = self.get_eip()
+            else:
+                ea = self.get_area()
+                ixx, iyy, ixy = self.get_ic()
+                i11, i22 = self.get_ip()
+
             if warping:
-                j = self.get_j()
-                nu = self.get_nu_eff()
+                if self.is_composite():
+                    j = self.get_ej()
+                    nu = self.get_nu_eff()
+                else:
+                    j = self.get_j()
+                    nu = 0.0
+
                 delta_s = self.section_props.delta_s
                 omega = self.section_props.omega
                 psi_shear = self.section_props.psi_shear
@@ -1866,8 +1906,8 @@ class Section:
                 the results
 
         Returns:
-            Modulus-weighted first moments of area about the global axis (``eqx``,
-            ``eqy``)
+            Modulus-weighted first moments of area about the global axis (``e.qx``,
+            ``e.qy``)
 
         Raises:
             RuntimeError: If material properties have *not* been applied
@@ -1890,20 +1930,25 @@ class Section:
 
         return self.section_props.qx / e_ref, self.section_props.qy / e_ref
 
-    def get_ig(self):
+    def get_ig(self) -> tuple[float, float, float]:
         """Returns the cross-section global second moments of area.
+
+        This is a geometric only property, as such this can only be returned if material
+        properties have *not* been applied to the cross-section.
 
         Returns:
             Second moments of area about the global axis (``ixx_g``, ``iyy_g``,
             ``ixy_g``)
 
-        Note:
-            If material properties have been specified, returns the elastic modulus
-            weighted second moments of area :math:`E.I`.
-
         Raises:
+            RuntimeError: If material properties have been applied
             AssertionError: If a geometric analysis has not been performed
         """
+        if self.is_composite():
+            msg = "Attempting to get a geometric only property for a composite analysis"
+            msg += " (material properties have been applied). Consider using get_eig()."
+            raise RuntimeError(msg)
+
         try:
             assert self.section_props.ixx_g is not None
             assert self.section_props.ixy_g is not None
@@ -1915,6 +1960,52 @@ class Section:
             self.section_props.ixx_g,
             self.section_props.iyy_g,
             self.section_props.ixy_g,
+        )
+
+    def get_eig(
+        self,
+        e_ref: float | pre.Material = 1,
+    ) -> tuple[float, float, float]:
+        """Returns the modulus-weighted cross-section global second moments of area.
+
+        This is a composite only property, as such this can only be returned if material
+        properties have been applied to the cross-section.
+
+        This value can be transformed by providing a reference elastic modulus or a
+        material property.
+
+        Args:
+            e_ref: Reference elastic modulus or material property by which to transform
+                the results
+
+        Returns:
+            Modulus weighted second moments of area about the global axis (``e.ixx_g``,
+            ``e.iyy_g``, ``e.ixy_g``)
+
+        Raises:
+            RuntimeError: If material properties have *not* been applied
+            AssertionError: If a geometric analysis has not been performed
+        """
+        if not self.is_composite():
+            msg = "Attempting to get a composite only property for a geometric analysis"
+            msg += " (material properties have not been applied). Consider using"
+            msg += " get_ig()."
+            raise RuntimeError(msg)
+
+        # calculate e_ref (transformed elastic modulus)
+        e_ref = self.get_e_ref(e_ref=e_ref)
+
+        try:
+            assert self.section_props.ixx_g is not None
+            assert self.section_props.ixy_g is not None
+            assert self.section_props.iyy_g is not None
+        except AssertionError as e:
+            raise AssertionError("Conduct a geometric analysis.") from e
+
+        return (
+            self.section_props.ixx_g / e_ref,
+            self.section_props.iyy_g / e_ref,
+            self.section_props.ixy_g / e_ref,
         )
 
     def get_c(self) -> tuple[float, float]:
@@ -1937,17 +2028,22 @@ class Section:
     def get_ic(self) -> tuple[float, float, float]:
         """Returns the cross-section centroidal second moments of area.
 
+        This is a geometric only property, as such this can only be returned if material
+        properties have *not* been applied to the cross-section.
+
         Returns:
             Second moments of area about the centroidal axis (``ixx_c``, ``iyy_c``,
             ``ixy_c``)
 
-        Note:
-            If material properties have been specified, returns the elastic modulus
-            weighted second moments of area :math:`E.I`.
-
         Raises:
+            RuntimeError: If material properties have been applied
             AssertionError: If a geometric analysis has not been performed
         """
+        if self.is_composite():
+            msg = "Attempting to get a geometric only property for a composite analysis"
+            msg += " (material properties have been applied). Consider using get_eic()."
+            raise RuntimeError(msg)
+
         try:
             assert self.section_props.ixx_c is not None
             assert self.section_props.ixy_c is not None
@@ -1961,20 +2057,71 @@ class Section:
             self.section_props.ixy_c,
         )
 
+    def get_eic(
+        self,
+        e_ref: float | pre.Material = 1,
+    ) -> tuple[float, float, float]:
+        """Returns the modulus-weighted cross-section centroidal second moments of area.
+
+        This is a composite only property, as such this can only be returned if material
+        properties have been applied to the cross-section.
+
+        This value can be transformed by providing a reference elastic modulus or a
+        material property.
+
+        Args:
+            e_ref: Reference elastic modulus or material property by which to transform
+                the results
+
+        Returns:
+            Modulus weighted second moments of area about the centroidal axis
+            (``e.ixx_c``, ``e.iyy_c``, ``e.ixy_c``)
+
+        Raises:
+            RuntimeError: If material properties have *not* been applied
+            AssertionError: If a geometric analysis has not been performed
+        """
+        if not self.is_composite():
+            msg = "Attempting to get a composite only property for a geometric analysis"
+            msg += " (material properties have not been applied). Consider using"
+            msg += " get_ic()."
+            raise RuntimeError(msg)
+
+        # calculate e_ref (transformed elastic modulus)
+        e_ref = self.get_e_ref(e_ref=e_ref)
+
+        try:
+            assert self.section_props.ixx_c is not None
+            assert self.section_props.ixy_c is not None
+            assert self.section_props.iyy_c is not None
+        except AssertionError as e:
+            raise AssertionError("Conduct a geometric analysis.") from e
+
+        return (
+            self.section_props.ixx_c / e_ref,
+            self.section_props.iyy_c / e_ref,
+            self.section_props.ixy_c / e_ref,
+        )
+
     def get_z(self) -> tuple[float, float, float, float]:
         """Returns the cross-section centroidal elastic section moduli.
+
+        This is a geometric only property, as such this can only be returned if material
+        properties have *not* been applied to the cross-section.
 
         Returns:
             Elastic section moduli about the centroidal axis with respect to the top and
             bottom fibres (``zxx_plus``, ``zxx_minus``, ``zyy_plus``, ``zyy_minus``)
 
-        Note:
-            If material properties have been specified, returns the elastic modulus
-            weighted section moduli :math:`E.Z`.
-
         Raises:
+            RuntimeError: If material properties have been applied
             AssertionError: If a geometric analysis has not been performed
         """
+        if self.is_composite():
+            msg = "Attempting to get a geometric only property for a composite analysis"
+            msg += " (material properties have been applied). Consider using get_ez()."
+            raise RuntimeError(msg)
+
         try:
             assert self.section_props.zxx_plus is not None
             assert self.section_props.zxx_minus is not None
@@ -1988,6 +2135,55 @@ class Section:
             self.section_props.zxx_minus,
             self.section_props.zyy_plus,
             self.section_props.zyy_minus,
+        )
+
+    def get_ez(
+        self,
+        e_ref: float | pre.Material = 1,
+    ) -> tuple[float, float, float, float]:
+        """Returns the modulus-weighted cross-section centroidal elastic section moduli.
+
+        This is a composite only property, as such this can only be returned if material
+        properties have been applied to the cross-section.
+
+        This value can be transformed by providing a reference elastic modulus or a
+        material property.
+
+        Args:
+            e_ref: Reference elastic modulus or material property by which to transform
+                the results
+
+        Returns:
+            Modulus weighted elastic section moduli about the centroidal axis with
+            respect to the top and bottom fibres (``e.zxx_plus``, ``e.zxx_minus``,
+            ``e.zyy_plus``, ``e.zyy_minus``)
+
+        Raises:
+            RuntimeError: If material properties have *not* been applied
+            AssertionError: If a geometric analysis has not been performed
+        """
+        if not self.is_composite():
+            msg = "Attempting to get a composite only property for a geometric analysis"
+            msg += " (material properties have not been applied). Consider using"
+            msg += " get_z()."
+            raise RuntimeError(msg)
+
+        # calculate e_ref (transformed elastic modulus)
+        e_ref = self.get_e_ref(e_ref=e_ref)
+
+        try:
+            assert self.section_props.zxx_plus is not None
+            assert self.section_props.zxx_minus is not None
+            assert self.section_props.zyy_plus is not None
+            assert self.section_props.zyy_minus is not None
+        except AssertionError as e:
+            raise AssertionError("Conduct a geometric analysis.") from e
+
+        return (
+            self.section_props.zxx_plus / e_ref,
+            self.section_props.zxx_minus / e_ref,
+            self.section_props.zyy_plus / e_ref,
+            self.section_props.zyy_minus / e_ref,
         )
 
     def get_rc(self) -> tuple[float, float]:
@@ -2010,16 +2206,21 @@ class Section:
     def get_ip(self) -> tuple[float, float]:
         """Returns the cross-section principal second moments of area.
 
+        This is a geometric only property, as such this can only be returned if material
+        properties have *not* been applied to the cross-section.
+
         Returns:
             Second moments of area about the principal axis (``i11_c``, ``i22_c``)
 
-        Note:
-            If material properties have been specified, returns the elastic modulus
-            weighted second moments of area :math:`E.I`.
-
         Raises:
+            RuntimeError: If material properties have been applied
             AssertionError: If a geometric analysis has not been performed
         """
+        if self.is_composite():
+            msg = "Attempting to get a geometric only property for a composite analysis"
+            msg += " (material properties have been applied). Consider using get_eip()."
+            raise RuntimeError(msg)
+
         try:
             assert self.section_props.i11_c is not None
             assert self.section_props.i22_c is not None
@@ -2027,6 +2228,47 @@ class Section:
             raise AssertionError("Conduct a geometric analysis.") from e
 
         return self.section_props.i11_c, self.section_props.i22_c
+
+    def get_eip(
+        self,
+        e_ref: float | pre.Material = 1,
+    ) -> tuple[float, float]:
+        """Returns the modulus-weighted cross-section principal second moments of area.
+
+        This is a composite only property, as such this can only be returned if material
+        properties have been applied to the cross-section.
+
+        This value can be transformed by providing a reference elastic modulus or a
+        material property.
+
+        Args:
+            e_ref: Reference elastic modulus or material property by which to transform
+                the results
+
+        Returns:
+            Modulus weighted second moments of area about the principal axis
+            (``e.i11_c``, ``e.i22_c``)
+
+        Raises:
+            RuntimeError: If material properties have *not* been applied
+            AssertionError: If a geometric analysis has not been performed
+        """
+        if not self.is_composite():
+            msg = "Attempting to get a composite only property for a geometric analysis"
+            msg += " (material properties have not been applied). Consider using"
+            msg += " get_ip()."
+            raise RuntimeError(msg)
+
+        # calculate e_ref (transformed elastic modulus)
+        e_ref = self.get_e_ref(e_ref=e_ref)
+
+        try:
+            assert self.section_props.i11_c is not None
+            assert self.section_props.i22_c is not None
+        except AssertionError as e:
+            raise AssertionError("Conduct a geometric analysis.") from e
+
+        return self.section_props.i11_c / e_ref, self.section_props.i22_c / e_ref
 
     def get_phi(self) -> float:
         """Returns the cross-section principal bending angle.
@@ -2047,17 +2289,22 @@ class Section:
     def get_zp(self) -> tuple[float, float, float, float]:
         """Returns the cross-section principal elastic section moduli.
 
+        This is a geometric only property, as such this can only be returned if material
+        properties have *not* been applied to the cross-section.
+
         Returns:
             Elastic section moduli about the principal axis with respect to the top and
             bottom fibres (``z11_plus``, ``z11_minus``, ``z22_plus``, ``z22_minus``)
 
-        Note:
-            If material properties have been specified, returns the elastic modulus
-            weighted section moduli :math:`E.Z`.
-
         Raises:
+            RuntimeError: If material properties have been applied
             AssertionError: If a geometric analysis has not been performed
         """
+        if self.is_composite():
+            msg = "Attempting to get a geometric only property for a composite analysis"
+            msg += " (material properties have been applied). Consider using get_ezp()."
+            raise RuntimeError(msg)
+
         try:
             assert self.section_props.z11_plus is not None
             assert self.section_props.z11_minus is not None
@@ -2071,6 +2318,55 @@ class Section:
             self.section_props.z11_minus,
             self.section_props.z22_plus,
             self.section_props.z22_minus,
+        )
+
+    def get_ezp(
+        self,
+        e_ref: float | pre.Material = 1,
+    ) -> tuple[float, float, float, float]:
+        """Returns the modulus-weighted cross-section principal elastic section moduli.
+
+        This is a composite only property, as such this can only be returned if material
+        properties have been applied to the cross-section.
+
+        This value can be transformed by providing a reference elastic modulus or a
+        material property.
+
+        Args:
+            e_ref: Reference elastic modulus or material property by which to transform
+                the results
+
+        Returns:
+            Modulus weighted elastic section moduli about the principal axis with
+            respect to the top and bottom fibres (``e.z11_plus``, ``e.z11_minus``,
+            ``e.z22_plus``, ``e.z22_minus``)
+
+        Raises:
+            RuntimeError: If material properties have *not* been applied
+            AssertionError: If a geometric analysis has not been performed
+        """
+        if not self.is_composite():
+            msg = "Attempting to get a composite only property for a geometric analysis"
+            msg += " (material properties have not been applied). Consider using"
+            msg += " get_zp()."
+            raise RuntimeError(msg)
+
+        # calculate e_ref (transformed elastic modulus)
+        e_ref = self.get_e_ref(e_ref=e_ref)
+
+        try:
+            assert self.section_props.z11_plus is not None
+            assert self.section_props.z11_minus is not None
+            assert self.section_props.z22_plus is not None
+            assert self.section_props.z22_minus is not None
+        except AssertionError as e:
+            raise AssertionError("Conduct a geometric analysis.") from e
+
+        return (
+            self.section_props.z11_plus / e_ref,
+            self.section_props.z11_minus / e_ref,
+            self.section_props.z22_plus / e_ref,
+            self.section_props.z22_minus / e_ref,
         )
 
     def get_rp(self) -> tuple[float, float]:
@@ -2093,12 +2389,21 @@ class Section:
     def get_nu_eff(self) -> float:
         """Returns the cross-section effective Poisson's ratio.
 
+        This is a composite only property, as such this can only be returned if material
+        properties have been applied to the cross-section.
+
         Returns:
             Effective Poisson's ratio
 
         Raises:
+            RuntimeError: If material properties have *not* been applied
             AssertionError: If a geometric analysis has not been performed
         """
+        if not self.is_composite():
+            msg = "Attempting to get a composite only property for a geometric analysis"
+            msg += " (material properties have not been applied)."
+            raise RuntimeError(msg)
+
         try:
             assert self.section_props.nu_eff is not None
         except AssertionError as e:
@@ -2109,12 +2414,21 @@ class Section:
     def get_e_eff(self) -> float:
         """Returns the cross-section effective elastic modulus.
 
+        This is a composite only property, as such this can only be returned if material
+        properties have been applied to the cross-section.
+
         Returns:
             Effective elastic modulus based on area
 
         Raises:
+            RuntimeError: If material properties have *not* been applied
             AssertionError: If a geometric analysis has not been performed
         """
+        if not self.is_composite():
+            msg = "Attempting to get a composite only property for a geometric analysis"
+            msg += " (material properties have not been applied)."
+            raise RuntimeError(msg)
+
         try:
             assert self.section_props.e_eff is not None
         except AssertionError as e:
@@ -2125,12 +2439,21 @@ class Section:
     def get_g_eff(self) -> float:
         """Returns the cross-section effective shear modulus.
 
+        This is a composite only property, as such this can only be returned if material
+        properties have been applied to the cross-section.
+
         Returns:
             Effective shear modulus based on area
 
         Raises:
+            RuntimeError: If material properties have *not* been applied
             AssertionError: If a geometric analysis has not been performed
         """
+        if not self.is_composite():
+            msg = "Attempting to get a composite only property for a geometric analysis"
+            msg += " (material properties have not been applied)."
+            raise RuntimeError(msg)
+
         try:
             assert self.section_props.g_eff is not None
         except AssertionError as e:
@@ -2141,22 +2464,66 @@ class Section:
     def get_j(self) -> float:
         """Returns the cross-section St. Venant torsion constant.
 
+        This is a geometric only property, as such this can only be returned if material
+        properties have *not* been applied to the cross-section.
+
         Returns:
             St. Venant torsion constant
 
-        Note:
-            If material properties have been specified, returns the elastic modulus
-            weighted torsion constant :math:`E.J`.
-
         Raises:
+            RuntimeError: If material properties have been applied
             AssertionError: If a warping analysis has not been performed
         """
+        if self.is_composite():
+            msg = "Attempting to get a geometric only property for a composite analysis"
+            msg += " (material properties have been applied). Consider using get_ej()."
+            raise RuntimeError(msg)
+
         try:
             assert self.section_props.j is not None
         except AssertionError as e:
             raise AssertionError("Conduct a warping analysis.") from e
 
         return self.section_props.j
+
+    def get_ej(
+        self,
+        e_ref: float | pre.Material = 1,
+    ) -> float:
+        """Returns the modulus-weighted cross-section St. Venant torsion constant.
+
+        This is a composite only property, as such this can only be returned if material
+        properties have been applied to the cross-section.
+
+        This value can be transformed by providing a reference elastic modulus or a
+        material property.
+
+        Args:
+            e_ref: Reference elastic modulus or material property by which to transform
+                the results
+
+        Returns:
+            Modulus weighted St. Venant torsion constant
+
+        Raises:
+            RuntimeError: If material properties have *not* been applied
+            AssertionError: If a warping analysis has not been performed
+        """
+        if not self.is_composite():
+            msg = "Attempting to get a composite only property for a geometric analysis"
+            msg += " (material properties have not been applied). Consider using"
+            msg += " get_j()."
+            raise RuntimeError(msg)
+
+        # calculate e_ref (transformed elastic modulus)
+        e_ref = self.get_e_ref(e_ref=e_ref)
+
+        try:
+            assert self.section_props.j is not None
+        except AssertionError as e:
+            raise AssertionError("Conduct a warping analysis.") from e
+
+        return self.section_props.j / e_ref
 
     def get_sc(self) -> tuple[float, float]:
         """Returns the cross-section centroidal shear centre (elasticity).
@@ -2200,10 +2567,10 @@ class Section:
         return self.section_props.x11_se, self.section_props.y22_se
 
     def get_sc_t(self) -> tuple[float, float]:
-        """Returns the cross-section centroidal shear centre (Trefftz's).
+        """Returns the cross-section centroidal shear centre (Trefftz's method).
 
         Returns:
-            Centroidal axis shear centre (Trefftz's approach) (``x_st``, ``y_st``)
+            Centroidal axis shear centre (Trefftz's method) (``x_st``, ``y_st``)
 
         Raises:
             AssertionError: If a warping analysis has not been performed
@@ -2223,18 +2590,24 @@ class Section:
         return x_st, y_st
 
     def get_gamma(self) -> float:
-        r"""Returns the cross-section warping constant.
+        """Returns the cross-section warping constant ($I_w$).
+
+        This is a geometric only property, as such this can only be returned if material
+        properties have *not* been applied to the cross-section.
 
         Returns:
             Warping constant
 
-        Note:
-            If material properties have been specified, returns the elastic modulus
-            weighted warping constant :math:`E.\Gamma`.
-
         Raises:
+            RuntimeError: If material properties have been applied
             AssertionError: If a warping analysis has not been performed
         """
+        if self.is_composite():
+            msg = "Attempting to get a geometric only property for a composite analysis"
+            msg += " (material properties have been applied). Consider using"
+            msg += " get_egamma()."
+            raise RuntimeError(msg)
+
         try:
             assert self.section_props.gamma is not None
         except AssertionError as e:
@@ -2242,19 +2615,63 @@ class Section:
 
         return self.section_props.gamma
 
+    def get_egamma(
+        self,
+        e_ref: float | pre.Material = 1,
+    ) -> float:
+        """Returns the modulus-weighted cross-section warping constant.
+
+        This is a composite only property, as such this can only be returned if material
+        properties have been applied to the cross-section.
+
+        This value can be transformed by providing a reference elastic modulus or a
+        material property.
+
+        Args:
+            e_ref: Reference elastic modulus or material property by which to transform
+                the results
+
+        Returns:
+            Modulus weighted warping constant
+
+        Raises:
+            RuntimeError: If material properties have *not* been applied
+            AssertionError: If a warping analysis has not been performed
+        """
+        if not self.is_composite():
+            msg = "Attempting to get a composite only property for a geometric analysis"
+            msg += " (material properties have not been applied). Consider using"
+            msg += " get_gamma()."
+            raise RuntimeError(msg)
+
+        # calculate e_ref (transformed elastic modulus)
+        e_ref = self.get_e_ref(e_ref=e_ref)
+
+        try:
+            assert self.section_props.gamma is not None
+        except AssertionError as e:
+            raise AssertionError("Conduct a warping analysis.") from e
+
+        return self.section_props.gamma / e_ref
+
     def get_as(self) -> tuple[float, float]:
         """Returns the cross-section centroidal axis shear area.
+
+        This is a geometric only property, as such this can only be returned if material
+        properties have *not* been applied to the cross-section.
 
         Returns:
             Shear area for loading about the centroidal axis (``a_sx``, ``a_sy``)
 
-        Note:
-            If material properties have been specified, returns the elastic modulus
-            weighted shear areas :math:`E.A_s`.
-
         Raises:
+            RuntimeError: If material properties have been applied
             AssertionError: If a warping analysis has not been performed
         """
+        if self.is_composite():
+            msg = "Attempting to get a geometric only property for a composite analysis"
+            msg += " (material properties have been applied). Consider using get_eas()."
+            raise RuntimeError(msg)
+
         try:
             assert self.section_props.a_sx is not None
             assert self.section_props.a_sy is not None
@@ -2263,20 +2680,67 @@ class Section:
 
         return self.section_props.a_sx, self.section_props.a_sy
 
+    def get_eas(
+        self,
+        e_ref: float | pre.Material = 1,
+    ) -> tuple[float, float]:
+        """Returns modulus-weighted the cross-section centroidal axis shear area.
+
+        This is a composite only property, as such this can only be returned if material
+        properties have been applied to the cross-section.
+
+        This value can be transformed by providing a reference elastic modulus or a
+        material property.
+
+        Args:
+            e_ref: Reference elastic modulus or material property by which to transform
+                the results
+
+        Returns:
+            Modulus weighted shear area for loading about the centroidal axis
+            (``e.a_sx``, ``e.a_sy``)
+
+        Raises:
+            RuntimeError: If material properties have *not* been applied
+            AssertionError: If a warping analysis has not been performed
+        """
+        if not self.is_composite():
+            msg = "Attempting to get a composite only property for a geometric analysis"
+            msg += " (material properties have not been applied). Consider using"
+            msg += " get_as()."
+            raise RuntimeError(msg)
+
+        # calculate e_ref (transformed elastic modulus)
+        e_ref = self.get_e_ref(e_ref=e_ref)
+
+        try:
+            assert self.section_props.a_sx is not None
+            assert self.section_props.a_sy is not None
+        except AssertionError as e:
+            raise AssertionError("Conduct a warping analysis.") from e
+
+        return self.section_props.a_sx / e_ref, self.section_props.a_sy / e_ref
+
     def get_as_p(self) -> tuple[float, float]:
         """Returns the cross-section princicpal axis shear area.
+
+        This is a geometric only property, as such this can only be returned if material
+        properties have *not* been applied to the cross-section.
 
         Returns:
             Shear area for loading about the princicpal bending axis (``a_s11``,
             ``a_s22``)
 
-        Note:
-            If material properties have been specified, returns the elastic modulus
-            weighted shear areas :math:`E.A_s`.
-
         Raises:
+            RuntimeError: If material properties have been applied
             AssertionError: If a warping analysis has not been performed
         """
+        if self.is_composite():
+            msg = "Attempting to get a geometric only property for a composite analysis"
+            msg += " (material properties have been applied). Consider using"
+            msg += " get_eas_p()."
+            raise RuntimeError(msg)
+
         try:
             assert self.section_props.a_s11 is not None
             assert self.section_props.a_s22 is not None
@@ -2284,6 +2748,47 @@ class Section:
             raise AssertionError("Conduct a warping analysis.") from e
 
         return self.section_props.a_s11, self.section_props.a_s22
+
+    def get_eas_p(
+        self,
+        e_ref: float | pre.Material = 1,
+    ) -> tuple[float, float]:
+        """Returns the modulus-weighted cross-section princicpal axis shear area.
+
+        This is a composite only property, as such this can only be returned if material
+        properties have been applied to the cross-section.
+
+        This value can be transformed by providing a reference elastic modulus or a
+        material property.
+
+        Args:
+            e_ref: Reference elastic modulus or material property by which to transform
+                the results
+
+        Returns:
+            Modulus weighted shear area for loading about the princicpal bending axis
+            (``e.a_s11``, ``e.a_s22``)
+
+        Raises:
+            RuntimeError: If material properties have *not* been applied
+            AssertionError: If a warping analysis has not been performed
+        """
+        if not self.is_composite():
+            msg = "Attempting to get a composite only property for a geometric analysis"
+            msg += " (material properties have not been applied). Consider using"
+            msg += " get_ig()."
+            raise RuntimeError(msg)
+
+        # calculate e_ref (transformed elastic modulus)
+        e_ref = self.get_e_ref(e_ref=e_ref)
+
+        try:
+            assert self.section_props.a_s11 is not None
+            assert self.section_props.a_s22 is not None
+        except AssertionError as e:
+            raise AssertionError("Conduct a warping analysis.") from e
+
+        return self.section_props.a_s11 / e_ref, self.section_props.a_s22 / e_ref
 
     def get_beta(self) -> tuple[float, float, float, float]:
         """Returns the cross-section global monosymmetry constants.
@@ -2397,16 +2902,49 @@ class Section:
     def get_s(self) -> tuple[float, float]:
         """Returns the cross-section centroidal plastic section moduli.
 
+        This is a geometric only property, as such this can only be returned if material
+        properties have *not* been applied to the cross-section.
+
         Returns:
             Plastic section moduli about the centroidal axis (``sxx``, ``syy``)
 
-        Note:
-            If material properties have been specified, returns the plastic moment
-            :math:`M_p = f_y S`.
-
         Raises:
+            RuntimeError: If material properties have been applied
             AssertionError: If a plastic analysis has not been performed
         """
+        if self.is_composite():
+            msg = "Attempting to get a geometric only property for a composite analysis"
+            msg += " (material properties have been applied). Consider using get_mp()."
+            raise RuntimeError(msg)
+
+        try:
+            assert self.section_props.sxx is not None
+            assert self.section_props.syy is not None
+        except AssertionError as e:
+            raise AssertionError("Conduct a plastic analysis.") from e
+
+        return self.section_props.sxx, self.section_props.syy
+
+    def get_mp(self) -> tuple[float, float]:
+        """Returns the cross-section plastic moment about the centroidal axis.
+
+        This is a composite only property, as such this can only be returned if material
+        properties have been applied to the cross-section.
+
+        Returns:
+            Plastic moment (:math:`M_p = f_y S`) about the centroidal axis (``mp_xx``,
+            ``mp_yy``)
+
+        Raises:
+            RuntimeError: If material properties have *not* been applied
+            AssertionError: If a plastic analysis has not been performed
+        """
+        if not self.is_composite():
+            msg = "Attempting to get a composite only property for a geometric analysis"
+            msg += " (material properties have not been applied). Consider using"
+            msg += " get_s()."
+            raise RuntimeError(msg)
+
         try:
             assert self.section_props.sxx is not None
             assert self.section_props.syy is not None
@@ -2418,16 +2956,50 @@ class Section:
     def get_sp(self) -> tuple[float, float]:
         """Returns the cross-section principal axis plastic section moduli.
 
+        This is a geometric only property, as such this can only be returned if material
+        properties have *not* been applied to the cross-section.
+
         Returns:
             Plastic section moduli about the principal bending axis (``s11``, ``s22``)
 
-        Note:
-            If material properties have been specified, returns the plastic moment
-            :math:`M_p = f_y S`.
-
         Raises:
+            RuntimeError: If material properties have been applied
             AssertionError: If a plastic analysis has not been performed
         """
+        if self.is_composite():
+            msg = "Attempting to get a geometric only property for a composite analysis"
+            msg += " (material properties have been applied). Consider using"
+            msg += " get_mp_p()."
+            raise RuntimeError(msg)
+
+        try:
+            assert self.section_props.s11 is not None
+            assert self.section_props.s22 is not None
+        except AssertionError as e:
+            raise AssertionError("Conduct a plastic analysis.") from e
+
+        return self.section_props.s11, self.section_props.s22
+
+    def get_mp_p(self) -> tuple[float, float]:
+        """Returns the cross-section plastic moment about the principal axis.
+
+        This is a composite only property, as such this can only be returned if material
+        properties have been applied to the cross-section.
+
+        Returns:
+            Plastic moment (:math:`M_p = f_y S`) about the principal axis (``mp_11``,
+            ``mp_22``)
+
+        Raises:
+            RuntimeError: If material properties have *not* been applied
+            AssertionError: If a plastic analysis has not been performed
+        """
+        if not self.is_composite():
+            msg = "Attempting to get a composite only property for a geometric analysis"
+            msg += " (material properties have not been applied). Consider using"
+            msg += " get_sp()."
+            raise RuntimeError(msg)
+
         try:
             assert self.section_props.s11 is not None
             assert self.section_props.s22 is not None
@@ -2439,19 +3011,21 @@ class Section:
     def get_sf(self) -> tuple[float, float, float, float]:
         """Returns the cross-section centroidal axis shape factors.
 
+        This is a geometric only property, as such this can only be returned if material
+        properties have *not* been applied to the cross-section.
+
         Returns:
             Centroidal axis shape factors with respect to the top and bottom fibres
             (``sf_xx_plus``, ``sf_xx_minus``, ``sf_yy_plus``, ``sf_yy_minus``)
 
         Raises:
+            RuntimeError: If material properties have been applied
             AssertionError: If a plastic analysis has not been performed
-            ValueError: If material properties have been specified (shape factors are
-                not a valid section property)
         """
-        try:
-            assert self.section_props.sxx is not None
-        except AssertionError as e:
-            raise AssertionError("Conduct a plastic analysis.") from e
+        if self.is_composite():
+            msg = "Attempting to get a geometric only property for a composite analysis"
+            msg += " (material properties have been applied)."
+            raise RuntimeError(msg)
 
         try:
             assert self.section_props.sf_xx_plus is not None
@@ -2459,8 +3033,7 @@ class Section:
             assert self.section_props.sf_yy_plus is not None
             assert self.section_props.sf_yy_minus is not None
         except AssertionError as e:
-            msg = "Shape factors are not valid for a composite analysis."
-            raise ValueError(msg) from e
+            raise AssertionError("Conduct a plastic analysis.") from e
 
         return (
             self.section_props.sf_xx_plus,
@@ -2472,19 +3045,21 @@ class Section:
     def get_sf_p(self) -> tuple[float, float, float, float]:
         """Returns the cross-section principal axis shape factors.
 
+        This is a geometric only property, as such this can only be returned if material
+        properties have *not* been applied to the cross-section.
+
         Returns:
             Principal bending axis shape factors with respect to the top and bottom
             fibres (``sf_11_plus``, ``sf_11_minus``, ``sf_22_plus``, ``sf_22_minus``)
 
         Raises:
+            RuntimeError: If material properties have been applied
             AssertionError: If a plastic analysis has not been performed
-            ValueError: If material properties have been specified (shape factors are
-                not a valid section property)
         """
-        try:
-            assert self.section_props.sxx is not None
-        except AssertionError as e:
-            raise AssertionError("Conduct a plastic analysis.") from e
+        if self.is_composite():
+            msg = "Attempting to get a geometric only property for a composite analysis"
+            msg += " (material properties have been applied)."
+            raise RuntimeError(msg)
 
         try:
             assert self.section_props.sf_11_plus is not None
@@ -2492,8 +3067,7 @@ class Section:
             assert self.section_props.sf_22_plus is not None
             assert self.section_props.sf_22_minus is not None
         except AssertionError as e:
-            msg = "Shape factors are not valid for a composite analysis."
-            raise ValueError(msg) from e
+            raise AssertionError("Conduct a plastic analysis.") from e
 
         return (
             self.section_props.sf_11_plus,
@@ -2568,12 +3142,22 @@ class Section:
 
         # get relevant section properties
         cx, cy = self.get_c()
-        ixx, iyy, ixy = self.get_ic()
-        i11, i22 = self.get_ip()
+
+        if self.is_composite():
+            ixx, iyy, ixy = self.get_eic()
+            i11, i22 = self.get_eip()
+        else:
+            ixx, iyy, ixy = self.get_ic()
+            i11, i22 = self.get_ip()
 
         if warping:
-            j = self.get_j()
-            nu = self.get_nu_eff()
+            if self.is_composite():
+                j = self.get_ej()
+                nu = self.get_nu_eff()
+            else:
+                j = self.get_j()
+                nu = 0.0
+
             delta_s = self.section_props.delta_s
             omega = self.section_props.omega
             psi_shear = self.section_props.psi_shear
@@ -2592,7 +3176,7 @@ class Section:
             phi_shear = np.zeros(shape=self.num_nodes)
 
         sect_prop = {
-            "ea": self.get_ea(),
+            "ea": self.get_ea() if self.is_composite() else self.get_area(),
             "cx": cx,
             "cy": cy,
             "ixx": ixx,

--- a/tests/test_get_results.py
+++ b/tests/test_get_results.py
@@ -1,0 +1,186 @@
+"""Validation of cross-section property get methods."""
+
+from __future__ import annotations
+
+import pytest
+
+from sectionproperties.analysis import Section
+from sectionproperties.pre import Material
+from sectionproperties.pre.library import rectangular_section
+
+
+# sections setup
+geom_no_mat = rectangular_section(d=1, b=1)
+dummy_mat = Material(
+    name="test",
+    elastic_modulus=5,
+    poissons_ratio=0,
+    yield_strength=3,
+    density=2,
+    color="w",
+)
+geom_mat = rectangular_section(d=1, b=1, material=dummy_mat)
+geom_no_mat.create_mesh(mesh_sizes=0)
+geom_mat.create_mesh(mesh_sizes=0)
+rect_no_mat = Section(geom_no_mat)
+rect_mat = Section(geom_mat)
+
+
+def test_is_composite():
+    """Check whether section is composite or not."""
+    assert not rect_no_mat.is_composite()
+    assert rect_mat.is_composite()
+
+
+def test_get_e_ref():
+    """Check get_e_ref results."""
+    test_mat = Material(
+        name="test",
+        elastic_modulus=10,
+        poissons_ratio=0,
+        yield_strength=1,
+        density=1,
+        color="w",
+    )
+
+    assert rect_no_mat.get_e_ref(1) == 1
+    assert rect_no_mat.get_e_ref(100) == 100
+    assert rect_no_mat.get_e_ref(dummy_mat) == 5
+    assert rect_no_mat.get_e_ref(test_mat) == 10
+
+
+def test_no_analysis():
+    """Check errors when no analysis has been conducted.
+
+    RuntimeError = incorrect analysis type (geometric only vs. composite), takes
+    precedence over...
+    AssertionError = relevant analysis has been conducted
+    """
+    # check area
+    with pytest.raises(AssertionError):
+        rect_no_mat.get_area()
+
+    # check perimeter
+    with pytest.raises(AssertionError):
+        rect_no_mat.get_perimeter()
+
+    # check mass
+    with pytest.raises(RuntimeError):
+        rect_no_mat.get_mass()
+
+    with pytest.raises(AssertionError):
+        rect_mat.get_mass()
+
+    # check ea
+    with pytest.raises(RuntimeError):
+        rect_no_mat.get_mass()
+
+    with pytest.raises(AssertionError):
+        rect_mat.get_mass()
+
+    # check q
+    with pytest.raises(AssertionError):
+        rect_no_mat.get_q()
+
+    with pytest.raises(RuntimeError):
+        rect_mat.get_q()
+
+    # check eq
+    with pytest.raises(RuntimeError):
+        rect_no_mat.get_eq()
+
+    with pytest.raises(AssertionError):
+        rect_mat.get_eq()
+
+    # check ig
+    with pytest.raises(AssertionError):
+        rect_no_mat.get_ig()
+
+    with pytest.raises(RuntimeError):
+        rect_mat.get_ig()
+
+    # check eig
+    with pytest.raises(RuntimeError):
+        rect_no_mat.get_eig()
+
+    with pytest.raises(AssertionError):
+        rect_mat.get_eig()
+
+
+def test_get_geometric_only():
+    """Check errors and results when a geometric analysis has been conducted.
+
+    RuntimeError = incorrect analysis type (geometric only vs. composite)
+    """
+    rect_no_mat.calculate_geometric_properties()
+    rect_mat.calculate_geometric_properties()
+
+    # check area
+    assert rect_no_mat.get_area() == pytest.approx(1.0)
+    assert rect_mat.get_area() == pytest.approx(1.0)
+
+    # check perimeter
+    assert rect_no_mat.get_perimeter() == pytest.approx(4.0)
+    assert rect_mat.get_perimeter() == pytest.approx(4.0)
+
+    # check mass
+    with pytest.raises(RuntimeError):
+        rect_no_mat.get_mass()
+
+    assert rect_mat.get_mass() == pytest.approx(2.0)
+
+    # check ea
+    with pytest.raises(RuntimeError):
+        rect_no_mat.get_ea()
+
+    assert rect_mat.get_ea() == pytest.approx(5.0)
+    assert rect_mat.get_ea(e_ref=2) == pytest.approx(2.5)
+    assert rect_mat.get_ea(e_ref=dummy_mat) == pytest.approx(1.0)
+
+    # check q
+    qx, qy = rect_no_mat.get_q()
+    assert qx == pytest.approx(0.5)
+    assert qy == pytest.approx(0.5)
+
+    with pytest.raises(RuntimeError):
+        rect_mat.get_q()
+
+    # check eq
+    with pytest.raises(RuntimeError):
+        rect_no_mat.get_eq()
+
+    eqx, eqy = rect_mat.get_eq()
+    assert eqx == pytest.approx(2.5)
+    assert eqy == pytest.approx(2.5)
+    eqx, eqy = rect_mat.get_eq(e_ref=2)
+    assert eqx == pytest.approx(1.25)
+    assert eqy == pytest.approx(1.25)
+    eqx, eqy = rect_mat.get_eq(e_ref=dummy_mat)
+    assert eqx == pytest.approx(0.5)
+    assert eqy == pytest.approx(0.5)
+
+    # check ig
+    igxx, igyy, igxy = rect_no_mat.get_ig()
+    assert igxx == pytest.approx(1 / 3.0)
+    assert igyy == pytest.approx(1 / 3.0)
+    assert igxy == pytest.approx(0.25)
+
+    with pytest.raises(RuntimeError):
+        rect_mat.get_ig()
+
+    # check eig
+    with pytest.raises(RuntimeError):
+        rect_no_mat.get_eig()
+
+    eigxx, eigyy, eigxy = rect_mat.get_eig()
+    assert eigxx == pytest.approx(5.0 / 3)
+    assert eigyy == pytest.approx(5.0 / 3)
+    assert eigxy == pytest.approx(1.25)
+    eigxx, eigyy, eigxy = rect_mat.get_eig(e_ref=2)
+    assert eigxx == pytest.approx(5.0 / 6)
+    assert eigyy == pytest.approx(5.0 / 6)
+    assert eigxy == pytest.approx(0.625)
+    eigxx, eigyy, eigxy = rect_mat.get_eig(e_ref=dummy_mat)
+    assert eigxx == pytest.approx(1 / 3.0)
+    assert eigyy == pytest.approx(1 / 3.0)
+    assert eigxy == pytest.approx(0.25)

--- a/tests/test_get_results.py
+++ b/tests/test_get_results.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import numpy as np
 import pytest
 
 from sectionproperties.analysis import Section
@@ -30,6 +31,22 @@ def test_is_composite():
     """Check whether section is composite or not."""
     assert not rect_no_mat.is_composite()
     assert rect_mat.is_composite()
+
+    # check built up geometric only section
+    rect1 = rectangular_section(d=2, b=2)
+    rect2 = rectangular_section(d=4, b=5).shift_section(x_offset=2)
+    geom = rect1 + rect2
+    geom.create_mesh(mesh_sizes=[0])
+    sec = Section(geom)
+    assert not sec.is_composite()
+
+    # check section with hole geometric only section
+    rect_out = rectangular_section(d=10, b=10)
+    rect_in = rectangular_section(d=5, b=5).shift_section(x_offset=5, y_offset=5)
+    geom = rect_out - rect_in
+    geom.create_mesh(mesh_sizes=[0])
+    sec = Section(geom)
+    assert not sec.is_composite()
 
 
 def test_get_e_ref():
@@ -78,6 +95,9 @@ def test_no_analysis():
     with pytest.raises(AssertionError):
         rect_mat.get_mass()
 
+    with pytest.raises(AssertionError):
+        rect_mat.get_mass()
+
     # check q
     with pytest.raises(AssertionError):
         rect_no_mat.get_q()
@@ -105,6 +125,99 @@ def test_no_analysis():
 
     with pytest.raises(AssertionError):
         rect_mat.get_eig()
+
+    # check c
+    with pytest.raises(AssertionError):
+        rect_no_mat.get_c()
+
+    # check ic
+    with pytest.raises(AssertionError):
+        rect_no_mat.get_ic()
+
+    with pytest.raises(RuntimeError):
+        rect_mat.get_ic()
+
+    # check eic
+    with pytest.raises(RuntimeError):
+        rect_no_mat.get_eic()
+
+    with pytest.raises(AssertionError):
+        rect_mat.get_eic()
+
+    # check z
+    with pytest.raises(AssertionError):
+        rect_no_mat.get_z()
+
+    with pytest.raises(RuntimeError):
+        rect_mat.get_z()
+
+    # check ez
+    with pytest.raises(RuntimeError):
+        rect_no_mat.get_ez()
+
+    with pytest.raises(AssertionError):
+        rect_mat.get_ez()
+
+    # check rc
+    with pytest.raises(AssertionError):
+        rect_no_mat.get_rc()
+
+    # check ip
+    with pytest.raises(AssertionError):
+        rect_no_mat.get_ip()
+
+    with pytest.raises(RuntimeError):
+        rect_mat.get_ip()
+
+    # check eip
+    with pytest.raises(RuntimeError):
+        rect_no_mat.get_eip()
+
+    with pytest.raises(AssertionError):
+        rect_mat.get_eip()
+
+    # check phi
+    with pytest.raises(AssertionError):
+        rect_no_mat.get_phi()
+
+    # check zp
+    with pytest.raises(AssertionError):
+        rect_no_mat.get_zp()
+
+    with pytest.raises(RuntimeError):
+        rect_mat.get_zp()
+
+    # check ezp
+    with pytest.raises(RuntimeError):
+        rect_no_mat.get_ezp()
+
+    with pytest.raises(AssertionError):
+        rect_mat.get_ezp()
+
+    # check rp
+    with pytest.raises(AssertionError):
+        rect_no_mat.get_rc()
+
+    # check nu_eff
+    with pytest.raises(RuntimeError):
+        rect_no_mat.get_nu_eff()
+
+    with pytest.raises(AssertionError):
+        rect_mat.get_nu_eff()
+
+    # check e_eff
+    with pytest.raises(RuntimeError):
+        rect_no_mat.get_e_eff()
+
+    with pytest.raises(AssertionError):
+        rect_mat.get_e_eff()
+
+    # check g_eff
+    with pytest.raises(RuntimeError):
+        rect_no_mat.get_g_eff()
+
+    with pytest.raises(AssertionError):
+        rect_mat.get_g_eff()
 
 
 def test_get_geometric_only():
@@ -184,3 +297,214 @@ def test_get_geometric_only():
     assert eigxx == pytest.approx(1 / 3.0)
     assert eigyy == pytest.approx(1 / 3.0)
     assert eigxy == pytest.approx(0.25)
+
+    # check c
+    cx, cy = rect_no_mat.get_c()
+    assert cx == pytest.approx(1 / 2.0)
+    assert cy == pytest.approx(1 / 2.0)
+    cx, cy = rect_mat.get_c()
+    assert cx == pytest.approx(1 / 2.0)
+    assert cy == pytest.approx(1 / 2.0)
+
+    # check ic
+    icxx, icyy, icxy = rect_no_mat.get_ic()
+    assert icxx == pytest.approx(1 / 12.0)
+    assert icyy == pytest.approx(1 / 12.0)
+    assert icxy == pytest.approx(0.0)
+
+    with pytest.raises(RuntimeError):
+        rect_mat.get_ic()
+
+    # check eic
+    with pytest.raises(RuntimeError):
+        rect_no_mat.get_eic()
+
+    eicxx, eicyy, eicxy = rect_mat.get_eic()
+    assert eicxx == pytest.approx(5.0 / 12)
+    assert eicyy == pytest.approx(5.0 / 12)
+    assert eicxy == pytest.approx(0.0)
+    eicxx, eicyy, eicxy = rect_mat.get_eic(e_ref=2)
+    assert eicxx == pytest.approx(5.0 / 24)
+    assert eicyy == pytest.approx(5.0 / 24)
+    assert eicxy == pytest.approx(0.0)
+    eicxx, eicyy, eicxy = rect_mat.get_eic(e_ref=dummy_mat)
+    assert eicxx == pytest.approx(1 / 12.0)
+    assert eicyy == pytest.approx(1 / 12.0)
+    assert eicxy == pytest.approx(0.0)
+
+    # check z
+    zxx_plus, zxx_minus, zyy_plus, zyy_minus = rect_no_mat.get_z()
+    assert zxx_plus == pytest.approx(1 / 6.0)
+    assert zxx_minus == pytest.approx(1 / 6.0)
+    assert zyy_plus == pytest.approx(1 / 6.0)
+    assert zyy_minus == pytest.approx(1 / 6.0)
+
+    with pytest.raises(RuntimeError):
+        rect_mat.get_z()
+
+    # check ez
+    with pytest.raises(RuntimeError):
+        rect_no_mat.get_ez()
+
+    ezxx_plus, ezxx_minus, ezyy_plus, ezyy_minus = rect_mat.get_ez()
+    assert ezxx_plus == pytest.approx(5 / 6.0)
+    assert ezxx_minus == pytest.approx(5 / 6.0)
+    assert ezyy_plus == pytest.approx(5 / 6.0)
+    assert ezyy_minus == pytest.approx(5 / 6.0)
+    ezxx_plus, ezxx_minus, ezyy_plus, ezyy_minus = rect_mat.get_ez(e_ref=2)
+    assert ezxx_plus == pytest.approx(5 / 12.0)
+    assert ezxx_minus == pytest.approx(5 / 12.0)
+    assert ezyy_plus == pytest.approx(5 / 12.0)
+    assert ezyy_minus == pytest.approx(5 / 12.0)
+    ezxx_plus, ezxx_minus, ezyy_plus, ezyy_minus = rect_mat.get_ez(e_ref=dummy_mat)
+    assert ezxx_plus == pytest.approx(1 / 6.0)
+    assert ezxx_minus == pytest.approx(1 / 6.0)
+    assert ezyy_plus == pytest.approx(1 / 6.0)
+    assert ezyy_minus == pytest.approx(1 / 6.0)
+
+    # check rc
+    rcx, rcy = rect_no_mat.get_rc()
+    assert rcx == pytest.approx(np.sqrt(1 / 12.0))
+    assert rcy == pytest.approx(np.sqrt(1 / 12.0))
+    rcx, rcy = rect_mat.get_rc()
+    assert rcx == pytest.approx(np.sqrt(1 / 12.0))
+    assert rcy == pytest.approx(np.sqrt(1 / 12.0))
+
+    # check ip
+    i11, i22 = rect_no_mat.get_ip()
+    assert i11 == pytest.approx(1 / 12.0)
+    assert i22 == pytest.approx(1 / 12.0)
+
+    with pytest.raises(RuntimeError):
+        rect_mat.get_ip()
+
+    # check eip
+    with pytest.raises(RuntimeError):
+        rect_no_mat.get_eip()
+
+    ei11, ei22 = rect_mat.get_eip()
+    assert ei11 == pytest.approx(5.0 / 12)
+    assert ei22 == pytest.approx(5.0 / 12)
+    ei11, ei22 = rect_mat.get_eip(e_ref=2)
+    assert ei11 == pytest.approx(5.0 / 24)
+    assert ei22 == pytest.approx(5.0 / 24)
+    ei11, ei22 = rect_mat.get_eip(e_ref=dummy_mat)
+    assert ei11 == pytest.approx(1 / 12.0)
+    assert ei22 == pytest.approx(1 / 12.0)
+
+    # check phi
+    phi = rect_no_mat.get_phi()
+    assert phi == pytest.approx(0.0)
+    phi = rect_mat.get_phi()
+    assert phi == pytest.approx(0.0)
+
+    # check zp
+    z11_plus, z11_minus, z22_plus, z22_minus = rect_no_mat.get_zp()
+    assert z11_plus == pytest.approx(1 / 6.0)
+    assert z11_minus == pytest.approx(1 / 6.0)
+    assert z22_plus == pytest.approx(1 / 6.0)
+    assert z22_minus == pytest.approx(1 / 6.0)
+
+    with pytest.raises(RuntimeError):
+        rect_mat.get_z()
+
+    # check ezp
+    with pytest.raises(RuntimeError):
+        rect_no_mat.get_ezp()
+
+    ez11_plus, ez11_minus, ez22_plus, ez22_minus = rect_mat.get_ezp()
+    assert ez11_plus == pytest.approx(5 / 6.0)
+    assert ez11_minus == pytest.approx(5 / 6.0)
+    assert ez22_plus == pytest.approx(5 / 6.0)
+    assert ez22_minus == pytest.approx(5 / 6.0)
+    ez11_plus, ez11_minus, ez22_plus, ez22_minus = rect_mat.get_ezp(e_ref=2)
+    assert ez11_plus == pytest.approx(5 / 12.0)
+    assert ez11_minus == pytest.approx(5 / 12.0)
+    assert ez22_plus == pytest.approx(5 / 12.0)
+    assert ez22_minus == pytest.approx(5 / 12.0)
+    ez11_plus, ez11_minus, ez22_plus, ez22_minus = rect_mat.get_ezp(e_ref=dummy_mat)
+    assert ez11_plus == pytest.approx(1 / 6.0)
+    assert ez11_minus == pytest.approx(1 / 6.0)
+    assert ez22_plus == pytest.approx(1 / 6.0)
+    assert ez22_minus == pytest.approx(1 / 6.0)
+
+    # check rp
+    r11, r22 = rect_no_mat.get_rp()
+    assert r11 == pytest.approx(np.sqrt(1 / 12.0))
+    assert r22 == pytest.approx(np.sqrt(1 / 12.0))
+    r11, r22 = rect_mat.get_rp()
+    assert r11 == pytest.approx(np.sqrt(1 / 12.0))
+    assert r22 == pytest.approx(np.sqrt(1 / 12.0))
+
+    # check nu_eff
+    with pytest.raises(RuntimeError):
+        rect_no_mat.get_nu_eff()
+
+    assert rect_mat.get_nu_eff() == pytest.approx(0.0)
+
+    # check e_eff
+    with pytest.raises(RuntimeError):
+        rect_no_mat.get_e_eff()
+
+    assert rect_mat.get_e_eff() == pytest.approx(5.0)
+
+    # check g_eff
+    with pytest.raises(RuntimeError):
+        rect_no_mat.get_g_eff()
+
+    assert rect_mat.get_g_eff() == pytest.approx(2.5)
+
+
+def test_get_effective_material():
+    """Tests effective material properties."""
+    mat1 = Material(
+        name="test",
+        elastic_modulus=1,
+        poissons_ratio=0.5,  # g = 1 / 3
+        yield_strength=1,
+        density=1,
+        color="w",
+    )
+    mat2 = Material(
+        name="test",
+        elastic_modulus=2,
+        poissons_ratio=0.5,  # g = 2 / 3
+        yield_strength=1,
+        density=1,
+        color="w",
+    )
+    mat3 = Material(
+        name="test",
+        elastic_modulus=1,
+        poissons_ratio=0,  # g = 0.5
+        yield_strength=1,
+        density=1,
+        color="w",
+    )
+
+    rect1 = rectangular_section(d=2, b=2, material=mat1)
+    rect2 = rectangular_section(d=2, b=2, material=mat2)
+    rect3 = rectangular_section(d=2, b=2, material=mat3).shift_section(x_offset=2)
+    geom1 = rect1 + rect3
+    geom2 = rect2 + rect3
+
+    geom1.create_mesh(mesh_sizes=[0])
+    geom2.create_mesh(mesh_sizes=[0])
+    sec1 = Section(geom1)
+    sec2 = Section(geom2)
+    sec1.calculate_geometric_properties()
+    sec2.calculate_geometric_properties()
+
+    # test e_eff
+    assert sec1.get_e_eff() == pytest.approx(1.0)
+    assert sec2.get_e_eff() == pytest.approx((4 * 1 + 4 * 2) / 8)
+
+    # test g_eff
+    # g = e / (2 * (1 + nu))
+    assert sec1.get_g_eff() == pytest.approx((0.5 + 1 / 3.0) / 2)
+    assert sec2.get_g_eff() == pytest.approx((4 * 2 / 3.0 + 4 * 0.5) / 8)
+
+    # test nu_eff
+    # nu = ea / (2 * ga) - 1
+    assert sec1.get_nu_eff() == pytest.approx(4 / (2 * 5 / 3.0) - 1)
+    assert sec2.get_nu_eff() == pytest.approx(6 / (2 * 7 / 3.0) - 1)

--- a/tests/test_get_results.py
+++ b/tests/test_get_results.py
@@ -223,7 +223,9 @@ def test_no_analysis():
 def test_get_geometric_only():
     """Check errors and results when a geometric analysis has been conducted.
 
-    RuntimeError = incorrect analysis type (geometric only vs. composite)
+    RuntimeError = incorrect analysis type (geometric only vs. composite), takes
+    precedence over...
+    AssertionError = relevant analysis has been conducted
     """
     rect_no_mat.calculate_geometric_properties()
     rect_mat.calculate_geometric_properties()
@@ -453,6 +455,366 @@ def test_get_geometric_only():
         rect_no_mat.get_g_eff()
 
     assert rect_mat.get_g_eff() == pytest.approx(2.5)
+
+    # now check errors from performing no warping analysis
+    # check j
+    with pytest.raises(AssertionError):
+        rect_no_mat.get_j()
+
+    with pytest.raises(RuntimeError):
+        rect_mat.get_j()
+
+    # check ej
+    with pytest.raises(RuntimeError):
+        rect_no_mat.get_ej()
+
+    with pytest.raises(AssertionError):
+        rect_mat.get_ej()
+
+    # check sc
+    with pytest.raises(AssertionError):
+        rect_no_mat.get_sc()
+
+    with pytest.raises(AssertionError):
+        rect_mat.get_sc()
+
+    # check sc_p
+    with pytest.raises(AssertionError):
+        rect_no_mat.get_sc_p()
+
+    with pytest.raises(AssertionError):
+        rect_mat.get_sc_p()
+
+    # check sc_t
+    with pytest.raises(AssertionError):
+        rect_no_mat.get_sc_t()
+
+    with pytest.raises(AssertionError):
+        rect_mat.get_sc_t()
+
+    # check gamma
+    with pytest.raises(AssertionError):
+        rect_no_mat.get_gamma()
+
+    with pytest.raises(RuntimeError):
+        rect_mat.get_gamma()
+
+    # check egamma
+    with pytest.raises(RuntimeError):
+        rect_no_mat.get_egamma()
+
+    with pytest.raises(AssertionError):
+        rect_mat.get_egamma()
+
+    # check as
+    with pytest.raises(AssertionError):
+        rect_no_mat.get_as()
+
+    with pytest.raises(RuntimeError):
+        rect_mat.get_as()
+
+    # check eas
+    with pytest.raises(RuntimeError):
+        rect_no_mat.get_eas()
+
+    with pytest.raises(AssertionError):
+        rect_mat.get_eas()
+
+    # check as_p
+    with pytest.raises(AssertionError):
+        rect_no_mat.get_as_p()
+
+    with pytest.raises(RuntimeError):
+        rect_mat.get_as_p()
+
+    # check eas_p
+    with pytest.raises(RuntimeError):
+        rect_no_mat.get_eas_p()
+
+    with pytest.raises(AssertionError):
+        rect_mat.get_eas_p()
+
+    # check beta
+    with pytest.raises(AssertionError):
+        rect_no_mat.get_beta()
+
+    with pytest.raises(AssertionError):
+        rect_mat.get_beta()
+
+    # check beta_p
+    with pytest.raises(AssertionError):
+        rect_no_mat.get_beta_p()
+
+    with pytest.raises(AssertionError):
+        rect_mat.get_beta_p()
+
+    # check pc
+    with pytest.raises(AssertionError):
+        rect_no_mat.get_pc()
+
+    with pytest.raises(AssertionError):
+        rect_mat.get_pc()
+
+    # check pc_p
+    with pytest.raises(AssertionError):
+        rect_no_mat.get_pc_p()
+
+    with pytest.raises(AssertionError):
+        rect_mat.get_pc_p()
+
+    # check s
+    with pytest.raises(AssertionError):
+        rect_no_mat.get_s()
+
+    with pytest.raises(RuntimeError):
+        rect_mat.get_s()
+
+    # check mp
+    with pytest.raises(RuntimeError):
+        rect_no_mat.get_mp()
+
+    with pytest.raises(AssertionError):
+        rect_mat.get_mp()
+
+    # check sp
+    with pytest.raises(AssertionError):
+        rect_no_mat.get_sp()
+
+    with pytest.raises(RuntimeError):
+        rect_mat.get_sp()
+
+    # check mp_p
+    with pytest.raises(RuntimeError):
+        rect_no_mat.get_mp_p()
+
+    with pytest.raises(AssertionError):
+        rect_mat.get_mp_p()
+
+    # check sf
+    with pytest.raises(AssertionError):
+        rect_no_mat.get_sf()
+
+    with pytest.raises(RuntimeError):
+        rect_mat.get_sf()
+
+    # check sf_p
+    with pytest.raises(AssertionError):
+        rect_no_mat.get_sf_p()
+
+    with pytest.raises(RuntimeError):
+        rect_mat.get_sf_p()
+
+
+def test_get_warping():
+    """Check errors and results when a warping analysis has been conducted.
+
+    RuntimeError = incorrect analysis type (geometric only vs. composite), takes
+    precedence over...
+    AssertionError = relevant analysis has been conducted
+    """
+    rect_no_mat.calculate_geometric_properties()
+    rect_no_mat.calculate_warping_properties()
+    rect_mat.calculate_geometric_properties()
+    rect_mat.calculate_warping_properties()
+
+    # check j
+    assert rect_no_mat.get_j() == pytest.approx(1 / 6.0)
+
+    with pytest.raises(RuntimeError):
+        rect_mat.get_j()
+
+    # check ej
+    with pytest.raises(RuntimeError):
+        rect_no_mat.get_ej()
+
+    assert rect_mat.get_ej() == pytest.approx(5 / 6.0)
+    assert rect_mat.get_ej(e_ref=2) == pytest.approx(5 / 12.0)
+    assert rect_mat.get_ej(e_ref=dummy_mat) == pytest.approx(1 / 6.0)
+
+    # check sc
+    x_se, y_se = rect_no_mat.get_sc()
+    assert x_se == pytest.approx(0.5)
+    assert y_se == pytest.approx(0.5)
+    x_se, y_se = rect_mat.get_sc()
+    assert x_se == pytest.approx(0.5)
+    assert y_se == pytest.approx(0.5)
+
+    # check sc_p
+    x11_se, y22_se = rect_no_mat.get_sc_p()
+    assert x11_se == pytest.approx(0.0)
+    assert y22_se == pytest.approx(0.0)
+    x11_se, y22_se = rect_mat.get_sc_p()
+    assert x11_se == pytest.approx(0.0)
+    assert y22_se == pytest.approx(0.0)
+
+    # check sc_t
+    x_st, y_st = rect_no_mat.get_sc_t()
+    assert x_st == pytest.approx(0.5)
+    assert y_st == pytest.approx(0.5)
+    x_st, y_st = rect_mat.get_sc_t()
+    assert x_st == pytest.approx(0.5)
+    assert y_st == pytest.approx(0.5)
+
+    # check gamma
+    assert rect_no_mat.get_gamma() == pytest.approx(0.0)
+
+    with pytest.raises(RuntimeError):
+        rect_mat.get_gamma()
+
+    # check egamma
+    with pytest.raises(RuntimeError):
+        rect_no_mat.get_egamma()
+
+    assert rect_mat.get_egamma() == pytest.approx(0.0)
+    assert rect_mat.get_egamma(e_ref=2) == pytest.approx(0.0)
+    assert rect_mat.get_egamma(e_ref=dummy_mat) == pytest.approx(0.0)
+
+    # check as
+    a_sx, a_sy = rect_no_mat.get_as()
+    assert a_sx == pytest.approx(0.9523810)
+    assert a_sy == pytest.approx(0.9523810)
+
+    with pytest.raises(RuntimeError):
+        rect_mat.get_as()
+
+    # check eas
+    with pytest.raises(RuntimeError):
+        rect_no_mat.get_eas()
+
+    ea_sx, ea_sy = rect_mat.get_eas()
+    assert ea_sx == pytest.approx(0.9523810 * 5)
+    assert ea_sy == pytest.approx(0.9523810 * 5)
+    ea_sx, ea_sy = rect_mat.get_eas(e_ref=2)
+    assert ea_sx == pytest.approx(0.9523810 * 2.5)
+    assert ea_sy == pytest.approx(0.9523810 * 2.5)
+    ea_sx, ea_sy = rect_mat.get_eas(e_ref=dummy_mat)
+    assert ea_sx == pytest.approx(0.9523810)
+    assert ea_sy == pytest.approx(0.9523810)
+
+    # check as_p
+    a_s11, a_s22 = rect_no_mat.get_as_p()
+    assert a_s11 == pytest.approx(0.9523810)
+    assert a_s22 == pytest.approx(0.9523810)
+
+    with pytest.raises(RuntimeError):
+        rect_mat.get_as_p()
+
+    # check eas_p
+    with pytest.raises(RuntimeError):
+        rect_no_mat.get_eas_p()
+
+    ea_s11, ea_s22 = rect_mat.get_eas_p()
+    assert ea_s11 == pytest.approx(0.9523810 * 5)
+    assert ea_s22 == pytest.approx(0.9523810 * 5)
+    ea_s11, ea_s22 = rect_mat.get_eas_p(e_ref=2)
+    assert ea_s11 == pytest.approx(0.9523810 * 2.5)
+    assert ea_s22 == pytest.approx(0.9523810 * 2.5)
+    ea_s11, ea_s22 = rect_mat.get_eas_p(e_ref=dummy_mat)
+    assert ea_s11 == pytest.approx(0.9523810)
+    assert ea_s22 == pytest.approx(0.9523810)
+
+    # check beta
+    beta_x_plus, beta_x_minus, beta_y_plus, beta_y_minus = rect_no_mat.get_beta()
+    assert beta_x_plus == pytest.approx(0.0)
+    assert beta_x_minus == pytest.approx(0.0)
+    assert beta_y_plus == pytest.approx(0.0)
+    assert beta_y_minus == pytest.approx(0.0)
+    beta_x_plus, beta_x_minus, beta_y_plus, beta_y_minus = rect_mat.get_beta()
+    assert beta_x_plus == pytest.approx(0.0)
+    assert beta_x_minus == pytest.approx(0.0)
+    assert beta_y_plus == pytest.approx(0.0)
+    assert beta_y_minus == pytest.approx(0.0)
+
+    # check beta_p
+    beta_11_plus, beta_11_minus, beta_22_plus, beta_22_minus = rect_no_mat.get_beta_p()
+    assert beta_11_plus == pytest.approx(0.0)
+    assert beta_11_minus == pytest.approx(0.0)
+    assert beta_22_plus == pytest.approx(0.0)
+    assert beta_22_minus == pytest.approx(0.0)
+    beta_11_plus, beta_11_minus, beta_22_plus, beta_22_minus = rect_mat.get_beta_p()
+    assert beta_11_plus == pytest.approx(0.0)
+    assert beta_11_minus == pytest.approx(0.0)
+    assert beta_22_plus == pytest.approx(0.0)
+    assert beta_22_minus == pytest.approx(0.0)
+
+
+def test_get_plastic():
+    """Check errors and results when a plastic analysis has been conducted.
+
+    RuntimeError = incorrect analysis type (geometric only vs. composite), takes
+    precedence over...
+    AssertionError = relevant analysis has been conducted
+    """
+    rect_no_mat.calculate_plastic_properties()
+    rect_mat.calculate_plastic_properties()
+
+    # check pc
+    x_pc, y_pc = rect_no_mat.get_pc()
+    assert x_pc == pytest.approx(0.5)
+    assert y_pc == pytest.approx(0.5)
+    x_pc, y_pc = rect_mat.get_pc()
+    assert x_pc == pytest.approx(0.5)
+    assert y_pc == pytest.approx(0.5)
+
+    # check pc_p
+    x_pc, y_pc = rect_no_mat.get_pc_p()
+    assert x_pc == pytest.approx(0.5)
+    assert y_pc == pytest.approx(0.5)
+    x_pc, y_pc = rect_mat.get_pc_p()
+    assert x_pc == pytest.approx(0.5)
+    assert y_pc == pytest.approx(0.5)
+
+    # check s
+    sxx, syy = rect_no_mat.get_s()
+    assert sxx == pytest.approx(0.25)
+    assert syy == pytest.approx(0.25)
+
+    with pytest.raises(RuntimeError):
+        rect_mat.get_s()
+
+    # check mp
+    with pytest.raises(RuntimeError):
+        rect_no_mat.get_mp()
+
+    mp_xx, mp_yy = rect_mat.get_mp()
+    assert mp_xx == pytest.approx(0.75)
+    assert mp_yy == pytest.approx(0.75)
+
+    # check sp
+    sxx, syy = rect_no_mat.get_sp()
+    assert sxx == pytest.approx(0.25)
+    assert syy == pytest.approx(0.25)
+
+    with pytest.raises(RuntimeError):
+        rect_mat.get_sp()
+
+    # check mp_p
+    with pytest.raises(RuntimeError):
+        rect_no_mat.get_mp_p()
+
+    mp_xx, mp_yy = rect_mat.get_mp_p()
+    assert mp_xx == pytest.approx(0.75)
+    assert mp_yy == pytest.approx(0.75)
+
+    # check sf
+    sf_xx_plus, sf_xx_minus, sf_yy_plus, sf_yy_minus = rect_no_mat.get_sf()
+    assert sf_xx_plus == pytest.approx(1.5)
+    assert sf_xx_minus == pytest.approx(1.5)
+    assert sf_yy_plus == pytest.approx(1.5)
+    assert sf_yy_minus == pytest.approx(1.5)
+
+    with pytest.raises(RuntimeError):
+        rect_mat.get_sf()
+
+    # check sf_p
+    sf_11_plus, sf_11_minus, sf_22_plus, sf_22_minus = rect_no_mat.get_sf_p()
+    assert sf_11_plus == pytest.approx(1.5)
+    assert sf_11_minus == pytest.approx(1.5)
+    assert sf_22_plus == pytest.approx(1.5)
+    assert sf_22_minus == pytest.approx(1.5)
+
+    with pytest.raises(RuntimeError):
+        rect_mat.get_sf_p()
 
 
 def test_get_effective_material():

--- a/tests/test_plastic.py
+++ b/tests/test_plastic.py
@@ -46,8 +46,8 @@ def test_rectangle():
     sec_nomat.calculate_plastic_properties()
 
     assert sec_nomat.get_s()[0] == pytest.approx(sx)
-    assert sec_mat.get_s()[0] == pytest.approx(mp)
-    assert sec_mat.get_s()[0] / fy == sec_nomat.get_s()[0]
+    assert sec_mat.get_mp()[0] == pytest.approx(mp)
+    assert sec_mat.get_mp()[0] / fy == sec_nomat.get_s()[0]
 
 
 def test_plastic_centroid():


### PR DESCRIPTION
New implementation for getting cross-section property results, fixes #272.

New behaviour can be summarised as follows:
- First considers whether the analysis is purely geometric (no material properties applied) or composite (material properties applied).
- The following methods are modified or added (if the wrong analysis has been conducted i.e. geometric vs. composite, will raise an error with a helpful suggestion):
  - `get_mass()` (composite only), if geometric suggests to use `get_area()`
  -  `get_ea()` (composite only), if geometric suggests to use `get_area()`
  -  `get_q()` (geometric only), if composite suggests to use `get_eq()`
  - `get_eq()` (composite only), if geometric suggests to use `get_q()`
  - `get_ig()` (geometric only), if composite suggests to use `get_eig()`
  - `get_eig()` (composite only), if geometric suggests to use `get_ig()`
  - `get_ic()` (geometric only), if composite suggests to use `get_eic()`
  - `get_eic()` (composite only), if geometric suggests to use `get_ic()`
  - `get_z()` (geometric only), if composite suggests to use `get_ez()`
  - `get_ez()` (composite only), if geometric suggests to use `get_z()`
  - `get_ip()` (geometric only), if composite suggests to use `get_eip()`
  - `get_eip()` (composite only), if geometric suggests to use `get_ip()`
  - `get_zp()` (geometric only), if composite suggests to use `get_ezp()`
  - `get_ezp()` (composite only), if geometric suggests to use `get_zp()`
  - `get_nu_eff()`, `get_e_eff()`, `get_g_eff()` (composite only)
  -  `get_j()` (geometric only), if composite suggests to use `get_ej()`
  - `get_ej()` (composite only), if geometric suggests to use `get_j()`
  -  `get_gamma()` (geometric only), if composite suggests to use `get_egamma()`
  - `get_egamma()` (composite only), if geometric suggests to use `get_gamma()`
  -  `get_as()` (geometric only), if composite suggests to use `get_eas()`
  - `get_eas()` (composite only), if geometric suggests to use `get_as()`
  -  `get_as_p()` (geometric only), if composite suggests to use `get_eas_p()`
  - `get_eas_p()` (composite only), if geometric suggests to use `get_as_p()`
  -  `get_s()` (geometric only), if composite suggests to use `get_mp()`
  - `get_mp()` (composite only), if geometric suggests to use `get_s()`
  -  `get_sp()` (geometric only), if composite suggests to use `get_mp_p()`
  - `get_mp_p()` (composite only), if geometric suggests to use `get_sp()`
  -  `get_sf()`, `get_sf_p()`  (geometric only)
- The option to use a reference elastic modulus to obtain transformed properties is provided where applicable