### PR TITLE
Add option to specify minimum mesh angle

### DIFF
--- a/docs/examples/geometry/create_mesh.ipynb
+++ b/docs/examples/geometry/create_mesh.ipynb
@@ -217,7 +217,20 @@
    "source": [
     "## Modifying the Minimum Angle\n",
     "\n",
-    "TODO: implement first!"
+    "We can change the minimum mesh vertex angle by specifying a value for `min_angle`, by default this is set to 30 degrees. Note that reducing the minimum angle will reduce the mesh quality, but may solve issues with the mesh algorithm not converging. See [here](https://www.cs.cmu.edu/~quake/triangle.q.html) for more information. Setting this value to number greater than 33 may cause issues with the meshing algorithm not converging."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1b1facce-4791-457a-b8ab-bb8921ec1128",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "geom.create_mesh(mesh_sizes=30, min_angle=33)\n",
+    "Section(geom).plot_mesh(materials=False)\n",
+    "geom.create_mesh(mesh_sizes=30, min_angle=5.7)\n",
+    "Section(geom).plot_mesh(materials=False)"
    ]
   },
   {
@@ -233,7 +246,7 @@
    "id": "84d6a8ac",
    "metadata": {},
    "source": [
-    "By setting the argument ``coarse=True``, all quality, area and angle constraints are ignored and a coarse mesh is generated. This can be useful if only geometric or plastic properties are desired (which are mesh independent). Note that if ``coarse=True``, the values provided to ``mesh_sizes`` will be ignored.\n",
+    "By setting the argument ``coarse=True``, all quality, area and angle constraints are ignored and a coarse mesh is generated. This can be useful if only geometric or plastic properties are desired (which are mesh independent). Note that if ``coarse=True``, the values provided to ``mesh_sizes`` and ``min_angle`` will be ignored.\n",
     "\n",
     "The following example compares the mesh generated for a box girder section, with and without quality constraints."
    ]

--- a/src/sectionproperties/pre/geometry.py
+++ b/src/sectionproperties/pre/geometry.py
@@ -417,6 +417,7 @@ class Geometry:
     def create_mesh(
         self,
         mesh_sizes: float | list[float],
+        min_angle: float = 30.0,
         coarse: bool = False,
     ) -> Geometry:
         r"""Creates a quadratic triangular mesh from the Geometry object.
@@ -425,6 +426,14 @@ class Geometry:
             mesh_sizes: A float describing the maximum mesh element area to be used
                 within the Geometry-object finite-element mesh (may also be a list of
                 length 1).
+            min_angle: The meshing algorithm adds vertices to the mesh to ensure that no
+                angle smaller than the minimum angle (in degrees, rounded to 1 decimal
+                place). Note that small angles between input segments cannot be
+                eliminated. If the minimum angle is 20.7 deg or smaller, the
+                triangulation algorithm is theoretically guaranteed to terminate (given
+                sufficient precision). The algorithm often doesn't terminate for angles
+                greater than 33 deg. Some meshes may require angles well below 20 deg to
+                avoid problems associated with insufficient floating-point precision.
             coarse: If set to True, will create a coarse mesh (no area or quality
                 constraints)
 
@@ -432,8 +441,8 @@ class Geometry:
             ValueError: ``mesh_sizes`` is not valid
 
         Returns:
-            Geometry-object with mesh data stored in .mesh attribute. Returned
-            Geometry-object is self, not a new instance.
+            ``Geometry`` object with mesh data stored in ``.mesh`` attribute. Returned
+            ``Geometry`` object is self, not a new instance.
 
         Example:
             The following example creates a circular cross-section with a diameter of
@@ -467,6 +476,7 @@ class Geometry:
             holes=self.holes,
             control_points=self.control_points,
             mesh_sizes=mesh_size,
+            min_angle=min_angle,
             coarse=coarse,
         )
 
@@ -1882,6 +1892,7 @@ class CompoundGeometry(Geometry):
     def create_mesh(
         self,
         mesh_sizes: list[float],
+        min_angle: float = 30.0,
         coarse: bool = False,
     ) -> CompoundGeometry:
         """Creates a quadratic triangular mesh from the CompoundGeometry object.
@@ -1891,12 +1902,20 @@ class CompoundGeometry(Geometry):
                 the finite-element mesh for each Geometry object within the
                 CompoundGeometry object. If a list of length 1 is passed, then the one
                 size will be applied to all constituent Geometry meshes.
+            min_angle: The meshing algorithm adds vertices to the mesh to ensure that no
+                angle smaller than the minimum angle (in degrees, rounded to 1 decimal
+                place). Note that small angles between input segments cannot be
+                eliminated. If the minimum angle is 20.7 deg or smaller, the
+                triangulation algorithm is theoretically guaranteed to terminate (given
+                sufficient precision). The algorithm often doesn't terminate for angles
+                greater than 33 deg. Some meshes may require angles well below 20 deg to
+                avoid problems associated with insufficient floating-point precision.
             coarse: If set to True, will create a coarse mesh (no area or quality
                 constraints)
 
         Returns:
-            CompoundGeometry object with mesh data stored in .mesh attribute. Returned
-            Geometry object is self, not a new instance.
+            ``CompoundGeometry`` object with mesh data stored in ``.mesh`` attribute.
+            Returned ``CompoundGeometry`` object is self, not a new instance.
 
         Example:
             The following example creates a mesh for a plate with a hole, with a refined
@@ -1932,6 +1951,7 @@ class CompoundGeometry(Geometry):
             holes=self.holes,
             control_points=self.control_points,
             mesh_sizes=mesh_sizes,
+            min_angle=min_angle,
             coarse=coarse,
         )
 

--- a/src/sectionproperties/pre/pre.py
+++ b/src/sectionproperties/pre/pre.py
@@ -85,6 +85,7 @@ def create_mesh(
     holes: list[tuple[float, float]],
     control_points: list[tuple[float, float]],
     mesh_sizes: list[float] | float,
+    min_angle: float,
     coarse: bool,
 ) -> dict[str, Any]:
     """Generates a triangular mesh.
@@ -103,6 +104,14 @@ def create_mesh(
             enclosed by facets.
         mesh_sizes: List of maximum element areas for each region defined by a control
             point
+        min_angle: The meshing algorithm adds vertices to the mesh to ensure that no
+            angle smaller than the minimum angle (in degrees, rounded to 1 decimal
+            place). Note that small angles between input segments cannot be eliminated.
+            If the minimum angle is 20.7 deg or smaller, the triangulation algorithm is
+            theoretically guaranteed to terminate (given sufficient precision). The
+            algorithm often doesn't terminate for angles greater than 33 deg. Some
+            meshes may require angles well below 20 deg to avoid problems associated
+            with insufficient floating-point precision.
         coarse: If set to True, will create a coarse mesh (no area or quality
             constraints)
 
@@ -131,6 +140,6 @@ def create_mesh(
     if coarse:
         mesh = triangle.triangulate(tri, "pAo2")
     else:
-        mesh = triangle.triangulate(tri, "pq30Aao2")
+        mesh = triangle.triangulate(tri, f"pq{min_angle:.1f}Aao2")
 
     return mesh


### PR DESCRIPTION
Closes #259.

User can specify `min_angle` when calling `Geometry.create_mesh()`.