### PR TITLE
Proposed fix for non-recognized holes

### DIFF
--- a/src/sectionproperties/pre/geometry.py
+++ b/src/sectionproperties/pre/geometry.py
@@ -25,6 +25,8 @@ import sectionproperties.post.post as post
 import sectionproperties.pre.bisect_section as bisect
 import sectionproperties.pre.pre as pre
 
+SCALE_CONSTANT = 1e-9
+
 
 class Geometry:
     """Class for defining the geometry of a contiguous section of a single material.
@@ -2384,7 +2386,6 @@ class CompoundGeometry(Geometry):
         # Determine if new holes have been created or if existing
         # holes have been destroyed (or "filled in").
         resultant_holes = []
-        SCALE_CONSTANT = 1e-9
         unionized_poly = unary_union([geom.geom for geom in self.geoms])
         buffer_amount = unionized_poly.area * SCALE_CONSTANT
         unionized_poly = unionized_poly.buffer(buffer_amount)

--- a/src/sectionproperties/pre/geometry.py
+++ b/src/sectionproperties/pre/geometry.py
@@ -2384,7 +2384,10 @@ class CompoundGeometry(Geometry):
         # Determine if new holes have been created or if existing
         # holes have been destroyed (or "filled in").
         resultant_holes = []
+        SCALE_CONSTANT = 1e-9
         unionized_poly = unary_union([geom.geom for geom in self.geoms])
+        buffer_amount = unionized_poly.area * SCALE_CONSTANT
+        unionized_poly = unionized_poly.buffer(buffer_amount)
 
         if isinstance(unionized_poly, MultiPolygon):
             for poly in unionized_poly.geoms:

--- a/src/sectionproperties/pre/geometry.py
+++ b/src/sectionproperties/pre/geometry.py
@@ -25,6 +25,7 @@ import sectionproperties.post.post as post
 import sectionproperties.pre.bisect_section as bisect
 import sectionproperties.pre.pre as pre
 
+
 SCALE_CONSTANT = 1e-9
 
 

--- a/src/sectionproperties/pre/geometry.py
+++ b/src/sectionproperties/pre/geometry.py
@@ -1357,8 +1357,7 @@ class Geometry:
 
         Example:
             The following example performs a symmetric difference on two circles with
-            the ``|`` operator. A mesh is generated to highlight the regions that
-            remain:
+            the ``^`` operator:
 
             .. plot::
                 :include-source: True
@@ -1369,9 +1368,7 @@ class Geometry:
 
                 circ1 = circular_section(d=100, n=64)
                 circ2 = circular_section(d=100, n=64).shift_section(x_offset=35)
-                geom = circ1 ^ circ2
-                geom.create_mesh(mesh_sizes=5)
-                Section(geometry=geom).plot_mesh()
+                (circ1 ^ circ2).plot_geometry()
         """
         material = self.material or other.material
 


### PR DESCRIPTION
When the geometries resulting from an operation result in a MultiPolygon that only touch at points, a hole is not recognized in shapely but it is "recognized" by humans. To fix this problem, the hole needs to be recognized by shapely as part of a Polygon. One solution to fix this would be to buffer the geometry by a very small amount to force this switch from MultiPolygon to Polygon.