### PR TITLE
Allow unlipped cee and zed steel_sections

### DIFF
--- a/src/sectionproperties/pre/library/steel_sections.py
+++ b/src/sectionproperties/pre/library/steel_sections.py
@@ -1103,7 +1103,7 @@ def cee_section(
         points += sp_utils.draw_radius(
             pt=(b - t - r_in, t + r_in), r=r_in, theta=0, n=n_r, ccw=False
         )
-    
+
     # if the lip is shorter than the outer radius (curve only)
     elif l > t and l <= r_out:
         # construct a smaller corner for bottom right if t < l < r_out
@@ -1152,7 +1152,11 @@ def cee_section(
     elif l > t and l <= r_out:
         # construct a smaller corner for top right if t < l < r_out
         points += sp_utils.draw_radius(
-            pt=(b - t - r_in_l, d - t - r_in_l), r=r_in_l, theta=0.5 * np.pi, n=n_r, ccw=False
+            pt=(b - t - r_in_l, d - t - r_in_l),
+            r=r_in_l,
+            theta=0.5 * np.pi,
+            n=n_r,
+            ccw=False,
         )
         points += sp_utils.draw_radius(
             pt=(b - r_out_l, d - r_out_l), r=r_out_l, theta=0, n=n_r
@@ -1301,7 +1305,11 @@ def zed_section(
             pt=(t - b_l + r_out_l, d - r_out_l), r=r_out_l, theta=0.5 * np.pi, n=n_r
         )
         points += sp_utils.draw_radius(
-            pt=(2 * t - b_l + r_in_l, d - t - r_in_l), r=r_in_l, theta=np.pi, n=n_r, ccw=False
+            pt=(2 * t - b_l + r_in_l, d - t - r_in_l),
+            r=r_in_l,
+            theta=np.pi,
+            n=n_r,
+            ccw=False,
         )
 
     # if the lip length is less than the section thickness (no lip)

--- a/src/sectionproperties/pre/library/steel_sections.py
+++ b/src/sectionproperties/pre/library/steel_sections.py
@@ -1105,12 +1105,12 @@ def cee_section(
         )
     
     # if the lip is shorter than the outer radius (curve only)
-    elif t < l and l <= r_out:
+    elif l > t and l <= r_out:
         # construct a smaller corner for bottom right if t < l < r_out
         r_out_l = l
         r_in_l = max(l - t, 0)
         points += sp_utils.draw_radius(
-            pt=(b - r_out_l, r_out_l), r=r_out_l, theta=1.5 * np.pi, n=n_r)
+            pt=(b - r_out_l, r_out_l), r=r_out_l, theta=1.5 * np.pi, n=n_r
         )
         points += sp_utils.draw_radius(
             pt=(b - t - r_in_l, t + r_in_l), r=r_in_l, theta=0, n=n_r, ccw=False
@@ -1258,12 +1258,12 @@ def zed_section(
         r_out_l = l
         r_in_l = max(l - t, 0)
         points += sp_utils.draw_radius(
-            pt=(b_r - r_out_l, r_out_l), r=r_out_l, theta=1.5 * np.pi, n=n_r)
+            pt=(b_r - r_out_l, r_out_l), r=r_out_l, theta=1.5 * np.pi, n=n_r
         )
         points += sp_utils.draw_radius(
             pt=(b_r - t - r_in_l, t + r_in_l), r=r_in_l, theta=0, n=n_r, ccw=False
         )
-    
+
     # if the lip length is less than the section thickness (no lip)
     elif l <= t:
         # construct end as two points only
@@ -1295,7 +1295,7 @@ def zed_section(
         )
 
     # if the lip is shorter than the outer radius (curve only)
-    elif t < l and l <= r_out:
+    elif l > t and l <= r_out:
         # construct a smaller corner for top left if t < l < r_out
         points += sp_utils.draw_radius(
             pt=(t - b_l + r_out_l, d - r_out_l), r=r_out_l, theta=0.5 * np.pi, n=n_r

--- a/src/sectionproperties/pre/library/steel_sections.py
+++ b/src/sectionproperties/pre/library/steel_sections.py
@@ -1060,9 +1060,6 @@ def cee_section(
     Returns:
         Cee section geometry
 
-    Raises:
-        ValueError: Lip length must be greater than the outer radius
-
     Example:
         The following example creates a cee section with a depth of 125 mm, a width of
         30 mm, a lip of 30 mm, a thickness of 1.5 mm and an outer radius of 6 mm, using
@@ -1076,10 +1073,6 @@ def cee_section(
 
             cee_section(d=125, b=50, l=30, t=1.5, r_out=6, n_r=8).plot_geometry()
     """
-    # ensure the lip length is greater than the outer radius
-    if l < r_out:
-        raise ValueError("Lip length must be greater than the outer radius")
-
     points: list[tuple[float, float]] = []
 
     # calculate internal radius
@@ -1209,9 +1202,6 @@ def zed_section(
     Returns:
         Zed section geometry
 
-    Raises:
-        ValueError: Lip length must be greater than the outer radius
-
     Example:
         The following example creates a zed section with a depth of 100 mm, a left
         flange width of 40 mm, a right flange width of 50 mm, a lip of 20 mm, a
@@ -1228,10 +1218,6 @@ def zed_section(
                 d=100, b_l=40, b_r=50, l=20, t=1.2, r_out=5, n_r=8
             ).plot_geometry()
     """
-    # ensure the lip length is greater than the outer radius
-    if l < r_out:
-        raise ValueError("Lip length must be greater than the outer radius")
-
     points: list[tuple[float, float]] = []
 
     # calculate internal radius

--- a/src/sectionproperties/pre/library/steel_sections.py
+++ b/src/sectionproperties/pre/library/steel_sections.py
@@ -1051,7 +1051,7 @@ def cee_section(
     Args:
         d: Depth of the cee section
         b: Width of the cee section
-        l: Lip of the cee section
+        l: Lip of the cee section (which can be zero)
         t: Thickness of the cee section
         r_out: Outer radius of the cee section
         n_r: Number of points discretising the outer radius
@@ -1088,20 +1088,39 @@ def cee_section(
     # construct the outer bottom left radius
     points += sp_utils.draw_radius(pt=(r_out, r_out), r=r_out, theta=np.pi, n=n_r)
 
-    # construct the outer bottom right radius
-    points += sp_utils.draw_radius(
-        pt=(b - r_out, r_out), r=r_out, theta=1.5 * np.pi, n=n_r
-    )
+    # if the lip is longer than the outer radius (curve + straight section
+    if l > r_out:
+        # construct the outer bottom right radius
+        points += sp_utils.draw_radius(
+            pt=(b - r_out, r_out), r=r_out, theta=1.5 * np.pi, n=n_r
+        )
 
-    if r_out != l:
         # add next two points
         points.append((b, l))
         points.append((b - t, l))
 
-    # construct the inner bottom right radius
-    points += sp_utils.draw_radius(
-        pt=(b - t - r_in, t + r_in), r=r_in, theta=0, n=n_r, ccw=False
-    )
+        # construct the inner bottom right radius
+        points += sp_utils.draw_radius(
+            pt=(b - t - r_in, t + r_in), r=r_in, theta=0, n=n_r, ccw=False
+        )
+    
+    # if the lip is shorter than the outer radius (curve only)
+    elif t < l and l <= r_out:
+        # construct a smaller corner for bottom right if t < l < r_out
+        r_out_l = l
+        r_in_l = max(l - t, 0)
+        points += sp_utils.draw_radius(
+            pt=(b - r_out_l, r_out_l), r=r_out_l, theta=1.5 * np.pi, n=n_r)
+        )
+        points += sp_utils.draw_radius(
+            pt=(b - t - r_in_l, t + r_in_l), r=r_in_l, theta=0, n=n_r, ccw=False
+        )
+
+    # if the lip length is less than the section thickness (no lip)
+    elif l <= t:
+        # construct end as two points only
+        points.append((b, 0))
+        points.append((b, t))
 
     # construct the inner bottom left radius
     points += sp_utils.draw_radius(
@@ -1113,18 +1132,37 @@ def cee_section(
         pt=(t + r_in, d - t - r_in), r=r_in, theta=np.pi, n=n_r, ccw=False
     )
 
-    # construct the inner top right radius
-    points += sp_utils.draw_radius(
-        pt=(b - t - r_in, d - t - r_in), r=r_in, theta=0.5 * np.pi, n=n_r, ccw=False
-    )
+    # if the lip is longer than the outer radius (curve + straight section)
+    if l > r_out:
+        # construct the inner top right radius
+        points += sp_utils.draw_radius(
+            pt=(b - t - r_in, d - t - r_in), r=r_in, theta=0.5 * np.pi, n=n_r, ccw=False
+        )
 
-    if r_out != l:
         # add next two points
         points.append((b - t, d - l))
         points.append((b, d - l))
 
-    # construct the outer top right radius
-    points += sp_utils.draw_radius(pt=(b - r_out, d - r_out), r=r_out, theta=0, n=n_r)
+        # construct the outer top right radius
+        points += sp_utils.draw_radius(
+            pt=(b - r_out, d - r_out), r=r_out, theta=0, n=n_r
+        )
+
+    # if the lip is shorter than the outer radius (curve only)
+    elif l > t and l <= r_out:
+        # construct a smaller corner for top right if t < l < r_out
+        points += sp_utils.draw_radius(
+            pt=(b - t - r_in_l, d - t - r_in_l), r=r_in_l, theta=0.5 * np.pi, n=n_r, ccw=False
+        )
+        points += sp_utils.draw_radius(
+            pt=(b - r_out_l, d - r_out_l), r=r_out_l, theta=0, n=n_r
+        )
+
+    # if the lip length is less than the section thickness (no lip)
+    elif l <= t:
+        # construct end as two points only
+        points.append((b, d - t))
+        points.append((b, d))
 
     # construct the outer top left radius
     points += sp_utils.draw_radius(
@@ -1158,7 +1196,7 @@ def zed_section(
         d: Depth of the zed section
         b_l: Left flange width of the zed section
         b_r: Right flange width of the zed section
-        l: Lip of the zed section
+        l: Lip of the zed section (which can be zero)
         t: Thickness of the zed section
         r_out: Outer radius of the zed section
         n_r: Number of points discretising the outer radius
@@ -1198,20 +1236,39 @@ def zed_section(
     # construct the outer bottom left radius
     points += sp_utils.draw_radius(pt=(r_out, r_out), r=r_out, theta=np.pi, n=n_r)
 
-    # construct the outer bottom right radius
-    points += sp_utils.draw_radius(
-        pt=(b_r - r_out, r_out), r=r_out, theta=1.5 * np.pi, n=n_r
-    )
+    # if the lip is longer than the outer radius (curve + straight section
+    if l > r_out:
+        # construct the outer bottom right radius
+        points += sp_utils.draw_radius(
+            pt=(b_r - r_out, r_out), r=r_out, theta=1.5 * np.pi, n=n_r
+        )
 
-    if r_out != l:
         # add next two points
         points.append((b_r, l))
         points.append((b_r - t, l))
 
-    # construct the inner bottom right radius
-    points += sp_utils.draw_radius(
-        pt=(b_r - t - r_in, t + r_in), r=r_in, theta=0, n=n_r, ccw=False
-    )
+        # construct the inner bottom right radius
+        points += sp_utils.draw_radius(
+            pt=(b_r - t - r_in, t + r_in), r=r_in, theta=0, n=n_r, ccw=False
+        )
+
+    # if the lip is shorter than the outer radius (curve only)
+    elif l > t and l <= r_out:
+        # construct a smaller corner for bottom right if t < l < r_out
+        r_out_l = l
+        r_in_l = max(l - t, 0)
+        points += sp_utils.draw_radius(
+            pt=(b_r - r_out_l, r_out_l), r=r_out_l, theta=1.5 * np.pi, n=n_r)
+        )
+        points += sp_utils.draw_radius(
+            pt=(b_r - t - r_in_l, t + r_in_l), r=r_in_l, theta=0, n=n_r, ccw=False
+        )
+    
+    # if the lip length is less than the section thickness (no lip)
+    elif l <= t:
+        # construct end as two points only
+        points.append((b_r, 0))
+        points.append((b_r, t))
 
     # construct the inner bottom left radius
     points += sp_utils.draw_radius(
@@ -1221,20 +1278,37 @@ def zed_section(
     # construct the outer top right radius
     points += sp_utils.draw_radius(pt=(t - r_out, d - r_out), r=r_out, theta=0, n=n_r)
 
-    # construct the outer top left radius
-    points += sp_utils.draw_radius(
-        pt=(t - b_l + r_out, d - r_out), r=r_out, theta=0.5 * np.pi, n=n_r
-    )
+    # if the lip is longer than the outer radius (curve + straight section
+    if l > r_out:
+        # construct the outer top left radius
+        points += sp_utils.draw_radius(
+            pt=(t - b_l + r_out, d - r_out), r=r_out, theta=0.5 * np.pi, n=n_r
+        )
 
-    if r_out != l:
         # add the next two points
         points.append((t - b_l, d - l))
         points.append((t - b_l + t, d - l))
 
-    # construct the inner top left radius
-    points += sp_utils.draw_radius(
-        pt=(2 * t - b_l + r_in, d - t - r_in), r=r_in, theta=np.pi, n=n_r, ccw=False
-    )
+        # construct the inner top left radius
+        points += sp_utils.draw_radius(
+            pt=(2 * t - b_l + r_in, d - t - r_in), r=r_in, theta=np.pi, n=n_r, ccw=False
+        )
+
+    # if the lip is shorter than the outer radius (curve only)
+    elif t < l and l <= r_out:
+        # construct a smaller corner for top left if t < l < r_out
+        points += sp_utils.draw_radius(
+            pt=(t - b_l + r_out_l, d - r_out_l), r=r_out_l, theta=0.5 * np.pi, n=n_r
+        )
+        points += sp_utils.draw_radius(
+            pt=(2 * t - b_l + r_in_l, d - t - r_in_l), r=r_in_l, theta=np.pi, n=n_r, ccw=False
+        )
+
+    # if the lip length is less than the section thickness (no lip)
+    elif l <= t:
+        # construct end as two points only
+        points.append((t - b_l, d))
+        points.append((t - b_l, d - t))
 
     # construct the inner top right radius
     points += sp_utils.draw_radius(


### PR DESCRIPTION
_This PR recreates #285 , but is based upon the `hypermodern` branch from the outset instead!_

--- Original description below ---
Unlipped Cee sections are very common. For example, all track ("T") sections in the Steel Framing Industry Association standard sections, [as defined here](https://sfia.memberclicks.net/assets/TechFiles/sfia%20tech%20spec%202015%20updated%207.12.17.pdf), are unlipped Cee sections. However, section-properties currently explicitly throws an error if lip length l is set to anything less than r_out (the outer radius).

This pull request adds the ability to set l to zero - or anything less than r_out.

Note that I did have a question as to what to do for 0 < l < r_out. One option would be to throw an error in this case, but I opted instead for decreasing the outer radius commensurately, on the philosophy that fewer error conditions is probably better, but am happy to change this as well.

While unlipped Zed sections are less common than unlipped Cees, they do exist - and a nearly-identical update could be applied to zed_section() to allow unlipped zeds as well here.