### PR TITLE
Fix concrete_rectangular_section() bug when n_side=1

### DIFF
--- a/src/sectionproperties/pre/library/concrete_sections.py
+++ b/src/sectionproperties/pre/library/concrete_sections.py
@@ -149,10 +149,7 @@ def concrete_rectangular_section(
         x_i_side_left = c_side + dia_side / 2
         x_i_side_right = b - x_i_side_left
 
-        if n_side == 1:
-            spacing_side = 0
-        else:
-            spacing_side = (d - c_top - c_bot - dia_top / 2 - dia_bot / 2) / (
+        spacing_side = (d - c_top - c_bot - dia_top / 2 - dia_bot / 2) / (
                 n_side + 1
             )
     else:

--- a/src/sectionproperties/pre/library/concrete_sections.py
+++ b/src/sectionproperties/pre/library/concrete_sections.py
@@ -149,9 +149,7 @@ def concrete_rectangular_section(
         x_i_side_left = c_side + dia_side / 2
         x_i_side_right = b - x_i_side_left
 
-        spacing_side = (d - c_top - c_bot - dia_top / 2 - dia_bot / 2) / (
-                n_side + 1
-            )
+        spacing_side = (d - c_top - c_bot - dia_top / 2 - dia_bot / 2) / (n_side + 1)
     else:
         x_i_side_left = 0
         x_i_side_right = 0


### PR DESCRIPTION
```py
concrete = Material(
    name="Concrete",
    elastic_modulus=30.1e3,
    poissons_ratio=0.2,
    density=2.4e-6,
    yield_strength=32,
    color="lightgrey",
)

# define the steel material
steel = Material(
    name="Steel",
    elastic_modulus=200e3,
    poissons_ratio=0.3,
    yield_strength=500,
    density=7.85e-6,
    color="grey",
)

# create the geometry
geom = concrete_rectangular_section(
    d=500,
    b=400,
    dia_top=10,
    area_top=300,
    n_top=3,
    c_top=30,
    dia_bot=10,
    area_bot=300,
    n_bot=3,
    c_bot=30,
    dia_side=10,
    area_side=300,
    n_side=1,
    c_side=30,
    n_circle=10,
    conc_mat=concrete,
    steel_mat=steel,
)

geom.create_mesh(mesh_sizes=[200])
sec = Section(geometry=geom)
```

When `n_side=1`, `spacing_side` becomes zero, causing two rebars at the same location, boolean operations fail.