### PR TITLE
Add jupyter notebook instructions to Examples page

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -1,6 +1,25 @@
 Examples
 ========
 
+The following examples showcase the features of ``sectionproperties`` in an
+instructional manner, while also highlighting several validation tests and advanced
+applications. The below examples are available as jupyter notebooks and can be
+downloaded
+`here <https://github.com/robbievanleeuwen/section-properties/tree/master/docs/examples>`_
+(click on the file you would like to download, then click the download icon at the top
+of the file).
+
+To run these notebooks you must first install `jupyter notebook <https://jupyter.org/>`_
+by running ``pip install notebook`` in the same virtual environment in which
+``sectionproperties`` is installed. Next, navigate to the location of the downloaded
+examples and run ``jupyter notebook`` to open jupyter in the browser. Finally, double
+click an example file to open the notebook, and execute each cell by clicking the play
+button. More information on jupyter notebooks can be found
+`here <https://docs.jupyter.org/en/latest/>`_. Don't be afraid to
+`raise an issue <https://github.com/robbievanleeuwen/section-properties/issues>`_ or
+`post in the discussions page <https://github.com/robbievanleeuwen/section-properties/discussions>`_
+if you have trouble running any of the examples!
+
 Geometry
 --------
 


### PR DESCRIPTION
Adds a link to download the example notebooks and instructions to install and run `jupyter notebook`.

Requested in openjournals/joss-reviews#6105.