### PR TITLE
Update rhino3dm to allow python 3.12

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -71,6 +71,3 @@ To install ``sectionproperties`` with the above functionality, use the ``dxf`` a
 
     pip install sectionproperties[dxf]
     pip install sectionproperties[rhino]
-
-..  warning:: The "rhino" extras do not currently support python 3.12, this may only be
-  installed for python 3.9, 3.10 and 3.11.

--- a/noxfile.py
+++ b/noxfile.py
@@ -161,21 +161,15 @@ def tests(session: Session) -> None:
     Args:
         session: Nox session
     """
-    # if python version is 3.12, don't install rhino extras
-    if session.python == "3.12":
-        session.run_always(
-            "poetry", "install", "--only", "main", "--extras", "dxf", external=True
-        )
-    else:
-        session.run_always(
-            "poetry",
-            "install",
-            "--only",
-            "main",
-            "--extras",
-            "dxf rhino",
-            external=True,
-        )
+    session.run_always(
+        "poetry",
+        "install",
+        "--only",
+        "main",
+        "--extras",
+        "dxf rhino",
+        external=True,
+    )
 
     # install relevant tooling
     session.install("coverage[toml]", "pytest", "pygments", "pytest-check")

--- a/poetry.lock
+++ b/poetry.lock
@@ -3164,40 +3164,35 @@ dev = ["Shapely (==1.8.0)", "black", "flake8", "isort", "matplotlib", "numpy (==
 
 [[package]]
 name = "rhino3dm"
-version = "8.6.1"
+version = "8.6.0"
 description = "Python library based on OpenNURBS with a RhinoCommon style"
 optional = true
 python-versions = "*"
 files = [
-    {file = "rhino3dm-8.6.1-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:9b2e6460a65dad3905ba0f44e13b7206b27e9c3ddb121ff8e5aca420d0908631"},
-    {file = "rhino3dm-8.6.1-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:b50e8d46539f1f73357a85606ca3d73f7693ebdaa50c808da64e4f26240d942b"},
-    {file = "rhino3dm-8.6.1-cp310-cp310-macosx_14_0_universal2.whl", hash = "sha256:29d9ccccf0dbf076b6c0367da4578f27a75b1553e231f3d942fe3c7a592b5d67"},
-    {file = "rhino3dm-8.6.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4176aaf3518e78e885ab3293adade39ea475d0924ed28a737139e6809791531b"},
-    {file = "rhino3dm-8.6.1-cp310-cp310-win_amd64.whl", hash = "sha256:a62b7d9d33ae82ba4916e4e065a57ae897c4947c9ec61c2fc05d65da1dce6860"},
-    {file = "rhino3dm-8.6.1-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:9c2b4c109a95e31cf207d61ea70d0805b78bad554f4d7aa8cff4d1d8356f5dff"},
-    {file = "rhino3dm-8.6.1-cp311-cp311-macosx_12_0_universal2.whl", hash = "sha256:59e3540c8fcb8e1a783d9bf18d6d34c2e81c40bf5df99ed7bdfcd407355618c2"},
-    {file = "rhino3dm-8.6.1-cp311-cp311-macosx_14_0_universal2.whl", hash = "sha256:788ea0ed74c44d69355c0d411fa6eb0fa22d089b008160285736cff8a649e51b"},
-    {file = "rhino3dm-8.6.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5af9600c71ab2e8d8ecf6ca040425ee66041bd0a0f58e75237de8fc8442596db"},
-    {file = "rhino3dm-8.6.1-cp311-cp311-win_amd64.whl", hash = "sha256:a9e21994ce3c75e1f902f376b3090facc2f50f07381507d6bea9edb17ab14e59"},
-    {file = "rhino3dm-8.6.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:c51a2d66395fd059d5fcd806929317e520ac9d796a23972d3f9fd027436049d9"},
-    {file = "rhino3dm-8.6.1-cp312-cp312-macosx_12_0_universal2.whl", hash = "sha256:a1e6140eb077cf387aad9dbfc290b3272a29a93957425a1fe2b4c777652b8b77"},
-    {file = "rhino3dm-8.6.1-cp312-cp312-macosx_14_0_universal2.whl", hash = "sha256:067afbde087e25541cfbdd8240eadf980f47050323c17f4cbfd448402bd404fc"},
-    {file = "rhino3dm-8.6.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:53b513ac4108c4d82f891da96b1d42d7ada5e9858c1fd61928501e32dfe388bd"},
-    {file = "rhino3dm-8.6.1-cp312-cp312-win_amd64.whl", hash = "sha256:f36258879e4b639e9d065027c6b0e455801e614e53e57db812eba5ea30039ce7"},
-    {file = "rhino3dm-8.6.1-cp37-cp37m-macosx_11_0_x86_64.whl", hash = "sha256:f60b464b6af87f8dce36b69e145ea6f7adb1617a332fb95ed9290f2f402de439"},
-    {file = "rhino3dm-8.6.1-cp37-cp37m-macosx_12_0_x86_64.whl", hash = "sha256:4c0052f1b08a95f65515c5f45b29e2cfd54f2824246b123106e20b5800741b42"},
-    {file = "rhino3dm-8.6.1-cp37-cp37m-win_amd64.whl", hash = "sha256:e03b088400d48a5e5b93f7047548473d1ff98c722c70e279c4aa45869b0a719d"},
-    {file = "rhino3dm-8.6.1-cp38-cp38-macosx_11_0_x86_64.whl", hash = "sha256:e4a0aa23b5113ea189e487be6438dbd668fc7bd4f7e42555dda5d0131a1916e8"},
-    {file = "rhino3dm-8.6.1-cp38-cp38-macosx_12_0_x86_64.whl", hash = "sha256:396deba04f043aee7d3d5175a17206488aa68ab542a15dfbfff3f7bed36dbb9d"},
-    {file = "rhino3dm-8.6.1-cp38-cp38-macosx_14_0_universal2.whl", hash = "sha256:23d3b8b971afea1ae088615ad16a59bf7807d3c0532bfd7cbc0d5be00457c267"},
-    {file = "rhino3dm-8.6.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:406d7215d76d4dd97c636642f3e7d5390342f86122c1d12d1c5270a7448d1607"},
-    {file = "rhino3dm-8.6.1-cp38-cp38-win_amd64.whl", hash = "sha256:79523ef9dd50681d32771523371edaebf1ec4cbbbf0b604d4a88e52a3876c4bc"},
-    {file = "rhino3dm-8.6.1-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:48521b935ce98a471f9a000cf3104116784c7d007f476d5e74b83459fa62c75a"},
-    {file = "rhino3dm-8.6.1-cp39-cp39-macosx_12_0_x86_64.whl", hash = "sha256:b88c6a734db17b83b41969e958776459c42c115d7d8e1501a0297c238afa539f"},
-    {file = "rhino3dm-8.6.1-cp39-cp39-macosx_14_0_universal2.whl", hash = "sha256:0fdd0f1e4d7f512f579583a4027c23604a2f10e96baae82460158878c9e1f348"},
-    {file = "rhino3dm-8.6.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2d228327f8b9da5e74f463c8f76bdbc21bc8f98eeaae96ffe359280fd1880521"},
-    {file = "rhino3dm-8.6.1-cp39-cp39-win_amd64.whl", hash = "sha256:b1d44af1ed47995217a1acd5ac6458d520be57c82680a4320b6c1f67ae075aad"},
-    {file = "rhino3dm-8.6.1.tar.gz", hash = "sha256:8999a12654c2effafe4b8e8f06c3410b11405659f9964563a421094c30e376d0"},
+    {file = "rhino3dm-8.6.0-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:5bfcf14c91aea61b2f795d04d79005ea0b3d46bf59bc1cd2d7e2825d4f658dff"},
+    {file = "rhino3dm-8.6.0-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:bd879d3802b4261b928c76aaf1dfe23620b78f9b4621f12a7fdc5493af4ce2f8"},
+    {file = "rhino3dm-8.6.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:afe8bb0e053ece66572cf9e081cceac312630dffd6645f886f47a2b57a1f5e31"},
+    {file = "rhino3dm-8.6.0-cp310-cp310-win_amd64.whl", hash = "sha256:944c19c951beec21ab4d0eae31b3b1d42a89e253993165065eaaccda5adfb7de"},
+    {file = "rhino3dm-8.6.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:c99d0439ec3912ba3ef42c09eac69caab3469bb15ab3ae4aac0794b7b801bec6"},
+    {file = "rhino3dm-8.6.0-cp311-cp311-macosx_12_0_universal2.whl", hash = "sha256:e1fcbd2bc5e22e4a531e563f7939073b14bcd241df74e3615bae82bfe0949870"},
+    {file = "rhino3dm-8.6.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6950aa37c0395399430fe4f7730621393ec8a41e52b6a95354ad62fb3f09dbf4"},
+    {file = "rhino3dm-8.6.0-cp311-cp311-win_amd64.whl", hash = "sha256:23e216233eefa97165c3c5376913023decb84498272949b55a07796897c1afc9"},
+    {file = "rhino3dm-8.6.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:49568d95cbe84f085766bcc32949ce9fee89ccf84a749a942c109f78060e219d"},
+    {file = "rhino3dm-8.6.0-cp312-cp312-macosx_12_0_universal2.whl", hash = "sha256:c20887182016df8ac995cf3b564556b1557c08cde2f60222395817ec86439745"},
+    {file = "rhino3dm-8.6.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2586b1b6bd962197af85cffbd9ba344b28d88b76cb4b59f4d80b8b5a8c329673"},
+    {file = "rhino3dm-8.6.0-cp312-cp312-win_amd64.whl", hash = "sha256:13b28886a36514ad6da04d3a38240e0097d45cdda97560d56635db5d743bd0a8"},
+    {file = "rhino3dm-8.6.0-cp37-cp37m-macosx_11_0_x86_64.whl", hash = "sha256:5598762e6d90cf107b44c85d4b2d38676a719bda6ed5cc129694ce7ece16f956"},
+    {file = "rhino3dm-8.6.0-cp37-cp37m-macosx_12_0_x86_64.whl", hash = "sha256:f701f0b11d8dd6a2d3872c12da20eb7d4f574eb9e68e2b1ff16219b22770cef5"},
+    {file = "rhino3dm-8.6.0-cp37-cp37m-win_amd64.whl", hash = "sha256:e8e998af2912feee1f3b6ab874403cb9835f34be59307453183a69e4f55164a8"},
+    {file = "rhino3dm-8.6.0-cp38-cp38-macosx_11_0_x86_64.whl", hash = "sha256:586dcd7dd3c4c61db167cfd1024237c6f1fa37d177fae396d82588ab4218e289"},
+    {file = "rhino3dm-8.6.0-cp38-cp38-macosx_12_0_x86_64.whl", hash = "sha256:a62da3abfe3627881cc0e88710729b585d74e9be7cfa5349ed6eadf6108581b6"},
+    {file = "rhino3dm-8.6.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:96479959d7fa510771f2824b2c647d803508032f8275d0612569a92ede3708b4"},
+    {file = "rhino3dm-8.6.0-cp38-cp38-win_amd64.whl", hash = "sha256:ece40981a0e4d982ad17cf4fe76bb10b8476f2220b017807316bc0d38097aecf"},
+    {file = "rhino3dm-8.6.0-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:f4ddc62b94fc72980a7dd4408323ff20df1c6af76f05cca4a3acebd52f7e9312"},
+    {file = "rhino3dm-8.6.0-cp39-cp39-macosx_12_0_x86_64.whl", hash = "sha256:cd205981c6d3ce0adff2379f1675433128d3f046bb279a7b6c59acaf9b075f31"},
+    {file = "rhino3dm-8.6.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:be44612e2f50759e5562dd7aefde1bf203737f921d5d62121f6008540f9016f5"},
+    {file = "rhino3dm-8.6.0-cp39-cp39-win_amd64.whl", hash = "sha256:a61e7597fec4f7191ba2c59fa919f745a5e9995f2e217e85795959763db5122d"},
+    {file = "rhino3dm-8.6.0.tar.gz", hash = "sha256:a169db39f2aceb28e687cf8355ae22632daafa563b7d3764990e88f6ed296e20"},
 ]
 
 [[package]]
@@ -3833,15 +3828,16 @@ full = ["httpx (>=0.22.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.7
 
 [[package]]
 name = "tbb"
-version = "2021.12.0"
+version = "2021.10.0"
 description = "Intel® oneAPI Threading Building Blocks (oneTBB)"
 optional = true
 python-versions = "*"
 files = [
-    {file = "tbb-2021.12.0-py2.py3-none-manylinux1_i686.whl", hash = "sha256:f2cc9a7f8ababaa506cbff796ce97c3bf91062ba521e15054394f773375d81d8"},
-    {file = "tbb-2021.12.0-py2.py3-none-manylinux1_x86_64.whl", hash = "sha256:a925e9a7c77d3a46ae31c34b0bb7f801c4118e857d137b68f68a8e458fcf2bd7"},
-    {file = "tbb-2021.12.0-py3-none-win32.whl", hash = "sha256:b1725b30c174048edc8be70bd43bb95473f396ce895d91151a474d0fa9f450a8"},
-    {file = "tbb-2021.12.0-py3-none-win_amd64.whl", hash = "sha256:fc2772d850229f2f3df85f1109c4844c495a2db7433d38200959ee9265b34789"},
+    {file = "tbb-2021.10.0-py2.py3-none-macosx_10_15_x86_64.macosx_11_0_x86_64.whl", hash = "sha256:5049f3be64664897f33ac1474a1bb1cfa45274cd8f4541e91fee4eda5c4165b5"},
+    {file = "tbb-2021.10.0-py2.py3-none-manylinux1_i686.whl", hash = "sha256:46205d559a2bfd877e9ea9a674fb3efb5d6024bd5dc10ace78c16d9d2db5d921"},
+    {file = "tbb-2021.10.0-py2.py3-none-manylinux1_x86_64.whl", hash = "sha256:a201aa14e098f7f6c8e45e393382007d01552f92797283b46d550068717cfb8c"},
+    {file = "tbb-2021.10.0-py3-none-win32.whl", hash = "sha256:64815eb09c0720e9d59f9ce74b0fde23424cddcdd604941a122eba846a5eaa5f"},
+    {file = "tbb-2021.10.0-py3-none-win_amd64.whl", hash = "sha256:787745460f79dc92883ef237330db20f57382a3e9bcb088a1fa49abd6a96b1d6"},
 ]
 
 [[package]]
@@ -4327,10 +4323,10 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more
 [extras]
 dxf = ["cad-to-shapely"]
 numba = ["numba"]
-pardiso = ["intel-openmp", "mkl", "pypardiso"]
+pardiso = ["intel-openmp", "mkl", "pypardiso", "tbb"]
 rhino = ["rhino-shapley-interop", "rhino3dm"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9.0,<3.13"
-content-hash = "c33db64b6baa4c3aec237239ff5a467e635f6294d188a4d354ed70431bc964a8"
+content-hash = "84ad29e3e9ba0a64555a9ae8f01c1259df0d08ece506a63a5930aa470d961af4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,11 +59,12 @@ click = "^8.1.7"
 more-itertools = "^10.2.0"
 numba = { version = "^0.59.0", optional = true }
 cad-to-shapely = { version = "^0.3.1", optional = true }
-rhino-shapley-interop = { version = "^0.0.4", python = ">=3.9.0,<3.12", optional = true }
-rhino3dm = { version = "^8.4.0", python = ">=3.9.0,<3.12", optional = true }
+rhino-shapley-interop = { version = "^0.0.4", optional = true }
+rhino3dm = { version = "==8.6.0", optional = true }
 pypardiso = { version = "^0.4.5", optional = true }
 intel-openmp = { version = "==2023.2.0", optional = true }
 mkl = { version = "==2023.2.0", optional = true }
+tbb = { version = "==2021.10.0", optional = true }
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.2.0"
@@ -101,7 +102,7 @@ sphinxext-opengraph = "^0.9.1"
 dxf = ["cad-to-shapely"]
 rhino = ["rhino-shapley-interop", "rhino3dm"]
 numba = ["numba"]
-pardiso = ["pypardiso", "intel-openmp", "mkl"]
+pardiso = ["pypardiso", "intel-openmp", "mkl", "tbb"]
 
 [tool.poetry.scripts]
 sectionproperties = "sectionproperties.__main__:main"

--- a/tests/geometry/test_geometry.py
+++ b/tests/geometry/test_geometry.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import platform
-import sys
 from pathlib import Path
 
 import pytest
@@ -481,7 +480,6 @@ def test_geometry_from_dxf():
     assert sp_geom.Geometry.from_dxf(section_holes_dxf).geom.wkt == poly
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 12), reason="requires python < 3.12")
 def test_geometry_from_3dm_file_simple():
     """Tests loading geometry from a simple .3dm file."""
     section = Path(__file__).parent.absolute() / "3in x 2in.3dm"
@@ -490,7 +488,6 @@ def test_geometry_from_3dm_file_simple():
     assert (test.geom - exp).is_empty
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 12), reason="requires python < 3.12")
 def test_geometry_from_3dm_file_complex():
     """Tests loading geometry from a complex .3dm file."""
     section_3dm = Path(__file__).parent.absolute() / "complex_shape.3dm"
@@ -502,7 +499,6 @@ def test_geometry_from_3dm_file_complex():
     assert (test.geom - exp).is_empty
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 12), reason="requires python < 3.12")
 def test_geometry_from_3dm_file_compound():
     """Tests loading compound geometry from a .3dm file."""
     section_3dm = Path(__file__).parent.absolute() / "compound_shape.3dm"
@@ -514,7 +510,6 @@ def test_geometry_from_3dm_file_compound():
     assert (MultiPolygon([ii.geom for ii in test.geoms]) - MultiPolygon(exp)).is_empty
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 12), reason="requires python < 3.12")
 def test_geometry_from_3dm_encode():
     """Tests loading compound geometry from a .json file."""
     section_3dm = Path(__file__).parent.absolute() / "rhino_data.json"


### PR DESCRIPTION
Updates `rhino3dm` to `8.6.0`, also fixes a dependency issue with `tbb`.