### PR TITLE
Add uv dependency groups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,10 @@ jobs:
         run: uv python install ${{ env.DEFAULT_PYTHON_VERSION }}
 
       - name: Install dependencies
-        run: uv sync -p ${{ env.DEFAULT_PYTHON_VERSION }} --frozen
+        run: uv sync -p ${{ env.DEFAULT_PYTHON_VERSION }} --frozen --only-group lint
 
       - name: Run pre-commit
-        run: uv run -p ${{ env.DEFAULT_PYTHON_VERSION }} pre-commit run --all-files --color always --show-diff-on-failure
+        run: uv run -p ${{ env.DEFAULT_PYTHON_VERSION }} --no-sync pre-commit run --all-files --color always --show-diff-on-failure
 
   type-checking:
     name: type-checking
@@ -57,10 +57,10 @@ jobs:
         run: uv python install ${{ env.DEFAULT_PYTHON_VERSION }}
 
       - name: Install dependencies
-        run: uv sync -p ${{ env.DEFAULT_PYTHON_VERSION }} --frozen --all-extras
+        run: uv sync -p ${{ env.DEFAULT_PYTHON_VERSION }} --frozen --all-extras --no-group test --no-group docs
 
       - name: Run pyright
-        run: uv run -p ${{ env.DEFAULT_PYTHON_VERSION }} pyright
+        run: uv run -p ${{ env.DEFAULT_PYTHON_VERSION }} --no-sync pyright
 
   tests:
     name: ${{ matrix.session }} ${{ matrix.python }} [${{ matrix.os }}]
@@ -98,14 +98,14 @@ jobs:
 
       - name: Install test dependencies
         if: matrix.session != 'tests-extended'
-        run: uv sync -p ${{ matrix.python }} --frozen --extra rhino --extra dxf
+        run: uv sync -p ${{ matrix.python }} --frozen --extra rhino --extra dxf --no-group docs --no-group lint
 
       - name: Install extended test dependencies
         if: matrix.session == 'tests-extended'
-        run: uv sync -p ${{ matrix.python }} --frozen --all-extras
+        run: uv sync -p ${{ matrix.python }} --frozen --all-extras --no-group docs --no-group lint
 
       - name: Run pytest
-        run: uv run -p ${{ matrix.python }} coverage run --parallel-mode -m pytest -m 'not benchmark_suite' --junitxml=junit.xml -o junit_family=legacy
+        run: uv run -p ${{ matrix.python }} --no-sync coverage run --parallel-mode -m pytest -m 'not benchmark_suite' --junitxml=junit.xml -o junit_family=legacy
 
       - name: Upload coverage data
         uses: actions/upload-artifact@v4
@@ -138,13 +138,13 @@ jobs:
         run: uv python install ${{ env.DEFAULT_PYTHON_VERSION }}
 
       - name: Install dependencies
-        run: uv sync -p ${{ env.DEFAULT_PYTHON_VERSION }} --frozen --extra rhino --extra dxf
+        run: uv sync -p ${{ env.DEFAULT_PYTHON_VERSION }} --frozen --extra rhino --extra dxf --no-group test --no-group lint
 
       - name: Install pandoc
         uses: pandoc/actions/setup@v1
 
       - name: Build docs
-        run: uv run -p ${{ env.DEFAULT_PYTHON_VERSION }} sphinx-build --color docs docs/_build
+        run: uv run -p ${{ env.DEFAULT_PYTHON_VERSION }} --no-sync sphinx-build --color docs docs/_build
 
       - name: Upload docs
         uses: actions/upload-artifact@v4
@@ -171,7 +171,7 @@ jobs:
         run: uv python install ${{ env.DEFAULT_PYTHON_VERSION }}
 
       - name: Install dependencies
-        run: uv sync -p ${{ env.DEFAULT_PYTHON_VERSION }} --frozen
+        run: uv sync -p ${{ env.DEFAULT_PYTHON_VERSION }} --frozen --only-group test
 
       - name: Download coverage data
         uses: actions/download-artifact@v4
@@ -180,13 +180,13 @@ jobs:
           merge-multiple: true
 
       - name: Combine coverage data
-        run: uv run -p ${{ env.DEFAULT_PYTHON_VERSION }} coverage combine
+        run: uv run -p ${{ env.DEFAULT_PYTHON_VERSION }} --no-sync coverage combine
 
       - name: Display coverage report
-        run: uv run -p ${{ env.DEFAULT_PYTHON_VERSION }} coverage report -i
+        run: uv run -p ${{ env.DEFAULT_PYTHON_VERSION }} --no-sync coverage report -i
 
       - name: Create coverage report
-        run: uv run -p ${{ env.DEFAULT_PYTHON_VERSION }} coverage xml -i
+        run: uv run -p ${{ env.DEFAULT_PYTHON_VERSION }} --no-sync coverage xml -i
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
 
     steps:
       - name: Check out the repository
@@ -50,16 +52,11 @@ jobs:
       - name: Publish package on PyPI
         if: steps.check-version.outputs.tag
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
 
       - name: Publish package on TestPyPI
         if: "! steps.check-version.outputs.tag"
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
 
       - name: Publish the release notes

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,5 +9,5 @@ build:
     - asdf install uv latest
     - asdf global uv latest
     - uv python install 3.12
-    - uv sync -p 3.12 --frozen --extra rhino --extra dxf
-    - uv run -p 3.12 -m sphinx -T -b html -d docs/_build/doctrees -D language=en docs $READTHEDOCS_OUTPUT/html
+    - uv sync -p 3.12 --frozen --extra rhino --extra dxf --no-group test --no-group lint
+    - uv run -p 3.12 --no-sync -m sphinx -T -b html -d docs/_build/doctrees -D language=en docs $READTHEDOCS_OUTPUT/html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,20 +45,13 @@ Installation instructions for other methods and Windows can be found [here](http
 `uv` can then be used to install the latest compatible version of python:
 
 ```shell
- uv python install 3.12
+uv python install 3.12
 ```
 
 `sectionproperties` and it's development dependencies can be installed with:
 
 ```shell
 uv sync
-```
-
-If you have other versions of python installed on your machine you may need to add the `-p` flag to ensure the correct version of python is used:
-
-```shell
-uv sync -p 3.12
-uv run -p 3.12 example.py
 ```
 
 Specific extras (e.g. `numba`) can be installed with the `--extra` flag or all extras with the `--all-extras` flag:

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -63,14 +63,6 @@ Installation instructions for other methods and Windows can be found
 
    uv sync
 
-If you have other versions of python installed on your machine you may need to add the
-``-p`` flag to ensure the correct version of python is used:
-
-.. code:: shell
-
-   uv sync -p 3.12
-   uv run -p 3.12 example.py
-
 Specific extras (e.g. ``numba``) can be installed with the ``--extra`` flag or all
 extras with the ``--all-extras`` flag:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,18 +60,8 @@ pardiso = [
     "pypardiso~=0.4.6; platform_system == 'Windows' or platform_system == 'Linux'"
 ]
 
-[tool.uv]
-dev-dependencies = [
-    # linting & code formatting
-    "ruff==0.7.1",
-    # type checking
-    "pyright==1.1.386",
-    # testing
-    "pytest==8.3.3",
-    "pytest-benchmark[histogram]==4.0.0",
-    "pytest-check==2.4.1",
-    "coverage[toml]==7.6.4",
-    # docs
+[dependency-groups]
+docs = [
     "furo==2024.8.6",
     "sphinx==8.1.3",
     "notebook==7.2.2",
@@ -81,9 +71,21 @@ dev-dependencies = [
     "nbconvert==7.16.4",
     "sphinx-copybutton==0.5.2",
     "sphinxext-opengraph==0.9.1",
-    # pre-commit
-    "pre-commit==4.0.1",
 ]
+test = [
+    "pytest==8.3.3",
+    "pytest-benchmark[histogram]==4.0.0",
+    "pytest-check==2.4.1",
+    "coverage[toml]==7.6.4",
+]
+lint = [
+    "pre-commit==4.0.1",
+    "ruff==0.7.1",
+    "pyright==1.1.386",
+]
+
+[tool.uv]
+default-groups = ["docs", "test", "lint"]
 
 [tool.pyright]
 venvPath = "."

--- a/uv.lock
+++ b/uv.lock
@@ -2140,24 +2140,28 @@ rhino = [
     { name = "rhino3dm" },
 ]
 
-[package.dev-dependencies]
-dev = [
-    { name = "coverage", extra = ["toml"] },
+[package.dependency-groups]
+docs = [
     { name = "furo" },
     { name = "ipykernel" },
     { name = "ipython" },
     { name = "nbconvert" },
     { name = "nbsphinx" },
     { name = "notebook" },
-    { name = "pre-commit" },
-    { name = "pyright" },
-    { name = "pytest" },
-    { name = "pytest-benchmark", extra = ["histogram"] },
-    { name = "pytest-check" },
-    { name = "ruff" },
     { name = "sphinx" },
     { name = "sphinx-copybutton" },
     { name = "sphinxext-opengraph" },
+]
+lint = [
+    { name = "pre-commit" },
+    { name = "pyright" },
+    { name = "ruff" },
+]
+test = [
+    { name = "coverage", extra = ["toml"] },
+    { name = "pytest" },
+    { name = "pytest-benchmark", extra = ["histogram"] },
+    { name = "pytest-check" },
 ]
 
 [package.metadata]
@@ -2176,24 +2180,28 @@ requires-dist = [
     { name = "shapely", specifier = "~=2.0.6" },
 ]
 
-[package.metadata.requires-dev]
-dev = [
-    { name = "coverage", extras = ["toml"], specifier = "==7.6.4" },
+[package.metadata.dependency-groups]
+docs = [
     { name = "furo", specifier = "==2024.8.6" },
     { name = "ipykernel", specifier = "==6.29.5" },
     { name = "ipython", specifier = "==8.29.0" },
     { name = "nbconvert", specifier = "==7.16.4" },
     { name = "nbsphinx", specifier = "==0.9.5" },
     { name = "notebook", specifier = "==7.2.2" },
-    { name = "pre-commit", specifier = "==4.0.1" },
-    { name = "pyright", specifier = "==1.1.386" },
-    { name = "pytest", specifier = "==8.3.3" },
-    { name = "pytest-benchmark", extras = ["histogram"], specifier = "==4.0.0" },
-    { name = "pytest-check", specifier = "==2.4.1" },
-    { name = "ruff", specifier = "==0.7.1" },
     { name = "sphinx", specifier = "==8.1.3" },
     { name = "sphinx-copybutton", specifier = "==0.5.2" },
     { name = "sphinxext-opengraph", specifier = "==0.9.1" },
+]
+lint = [
+    { name = "pre-commit", specifier = "==4.0.1" },
+    { name = "pyright", specifier = "==1.1.386" },
+    { name = "ruff", specifier = "==0.7.1" },
+]
+test = [
+    { name = "coverage", extras = ["toml"], specifier = "==7.6.4" },
+    { name = "pytest", specifier = "==8.3.3" },
+    { name = "pytest-benchmark", extras = ["histogram"], specifier = "==4.0.0" },
+    { name = "pytest-check", specifier = "==2.4.1" },
 ]
 
 [[package]]
@@ -2438,14 +2446,14 @@ wheels = [
 
 [[package]]
 name = "tinycss2"
-version = "1.3.0"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "webencodings" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/44/6f/38d2335a2b70b9982d112bb177e3dbe169746423e33f718bf5e9c7b3ddd3/tinycss2-1.3.0.tar.gz", hash = "sha256:152f9acabd296a8375fbca5b84c961ff95971fcfc32e79550c8df8e29118c54d", size = 67360 }
+sdist = { url = "https://files.pythonhosted.org/packages/7a/fd/7a5ee21fd08ff70d3d33a5781c255cbe779659bd03278feb98b19ee550f4/tinycss2-1.4.0.tar.gz", hash = "sha256:10c0972f6fc0fbee87c3edb76549357415e94548c1ae10ebccdea16fb404a9b7", size = 87085 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/4d/0db5b8a613d2a59bbc29bc5bb44a2f8070eb9ceab11c50d477502a8a0092/tinycss2-1.3.0-py3-none-any.whl", hash = "sha256:54a8dbdffb334d536851be0226030e9505965bb2f30f21a4a82c55fb2a80fae7", size = 22532 },
+    { url = "https://files.pythonhosted.org/packages/e6/34/ebdc18bae6aa14fbee1a08b63c015c72b64868ff7dae68808ab500c492e2/tinycss2-1.4.0-py3-none-any.whl", hash = "sha256:3a49cf47b7675da0b15d0c6e1df8df4ebd96e9394bb905a5775adb0d884c5289", size = 26610 },
 ]
 
 [[package]]


### PR DESCRIPTION
- Adds dependency groups (recently accepted [PEP735](https://peps.python.org/pep-0735/)) as supported by `uv==0.4.27`.
- Only install required dependencies in CI.
- Add `--no-sync` to `uv run` to ensure environment not updated after prior syncing.