### PR TITLE
Swap `find_holes` out for `filter_polygons` in `load_dxf` (`geometry.py`)

### DIFF
--- a/src/sectionproperties/pre/geometry.py
+++ b/src/sectionproperties/pre/geometry.py
@@ -2514,15 +2514,23 @@ def load_dxf(
     my_dxf.cleanup()
 
     polygons = my_dxf.polygons
-    new_polygons = c2s.utils.find_holes(polygons)
+    new_polygons = c2s.utils.filter_polygons(polygons)
 
-    if isinstance(new_polygons, MultiPolygon):
-        return CompoundGeometry(new_polygons)
-    elif isinstance(new_polygons, Polygon):  # pyright: ignore [reportUnnecessaryIsInstance]
-        return Geometry(new_polygons)
-    else:
+    # ensure list length > 0
+    if len(new_polygons) == 0:
         msg = f"No shapely.Polygon objects found in file: {dxf_filepath}"
         raise RuntimeError(msg)
+
+    # ensure only Polygons are generated
+    for poly in new_polygons:
+        if not isinstance(poly, Polygon):  # pyright: ignore [reportUnnecessaryIsInstance]
+            msg = f"Not all objects found in file: {dxf_filepath} are Polygons"
+            raise RuntimeError(msg)
+
+    if len(new_polygons) == 1:
+        return Geometry(new_polygons[0])
+    else:
+        return CompoundGeometry(MultiPolygon(new_polygons))
 
 
 def create_facets(

--- a/typings/cad_to_shapely/__init__.pyi
+++ b/typings/cad_to_shapely/__init__.pyi
@@ -1,2 +1,2 @@
 from .dxf import DxfImporter
-from .utils import find_holes
+from .utils import filter_polygons, find_holes

--- a/typings/cad_to_shapely/utils.pyi
+++ b/typings/cad_to_shapely/utils.pyi
@@ -1,3 +1,7 @@
 from shapely.geometry import Polygon
 
 def find_holes(polygons: list[Polygon]) -> Polygon: ...
+def filter_polygons(
+    polygons: list[Polygon],
+    filter_flag: int = ...,
+) -> list[Polygon]: ...


### PR DESCRIPTION
Fixes the deprecation warning from `cad-to-shapely` by using the updated function.

Thanks to @EdwardAstill (#509) for brining this to my attention!