### PR TITLE
Revert sphinx version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ dev = [
 ]
 docs = [
     "furo==2024.8.6",
-    "sphinx==8.2.3",
+    "sphinx==8.1.3",  # nbsphinx requies sphinx<8.2 for now
     "ipykernel==6.29.5",
     "ipython==9.2.0",
     "nbsphinx==0.9.7",


### PR DESCRIPTION
`nbsphinx` requires `sphinx<8.2` for now, see [here](https://github.com/spatialaudio/nbsphinx/issues/832).