### PR TITLE
Update core dependency specifiers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright © 2024 Robbie van Leeuwen
+Copyright © 2025 Robbie van Leeuwen
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,7 +3,7 @@
 # project information
 project = "sectionproperties"
 author = "Robbie van Leeuwen"
-copyright = "2024, Robbie van Leeuwen"  # noqa: A001
+copyright = "2025, Robbie van Leeuwen"  # noqa: A001
 
 # sphinx config
 templates_path = ["_templates"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,13 +29,13 @@ classifiers = [
 ]
 requires-python = ">=3.11,<3.14"
 dependencies = [
-    "numpy>=1.26.4",
-    "scipy>=1.14.1",
-    "matplotlib>=3.9.2",
-    "shapely>=2.0.7",
-    "cytriangle>=2.0.0",
-    "rich[jupyter]>=13.9.4",
-    "more-itertools>=10.5.0",
+    "numpy~=2.2",
+    "scipy~=1.14",
+    "matplotlib~=3.9",
+    "shapely~=2.0",
+    "cytriangle~=2.0",
+    "rich[jupyter]~=14.0",
+    "more-itertools~=10.5",
 ]
 
 [project.urls]

--- a/ruff.toml
+++ b/ruff.toml
@@ -17,6 +17,7 @@ select = [
   "ISC",    # flake8-implicit-str-concat
   "N",      # pep8-naming
   "NPY",    # NumPy-specific rules
+  "NPY201", # NumPy v2 compatibility checks
   "PERF",   # Perflint
   "PT",     # flake8-pytest-style
   "RUF",    # Ruff-specific

--- a/uv.lock
+++ b/uv.lock
@@ -2281,17 +2281,17 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "cad-to-shapely", marker = "extra == 'dxf'", specifier = ">=0.3.2" },
-    { name = "cytriangle", specifier = ">=2.0.0" },
-    { name = "matplotlib", specifier = ">=3.9.2" },
-    { name = "more-itertools", specifier = ">=10.5.0" },
+    { name = "cytriangle", specifier = "~=2.0" },
+    { name = "matplotlib", specifier = "~=3.9" },
+    { name = "more-itertools", specifier = "~=10.5" },
     { name = "numba", marker = "extra == 'numba'", specifier = ">=0.60.0" },
-    { name = "numpy", specifier = ">=1.26.4" },
+    { name = "numpy", specifier = "~=2.2" },
     { name = "pypardiso", marker = "(sys_platform == 'linux' and extra == 'pardiso') or (sys_platform == 'win32' and extra == 'pardiso')", specifier = ">=0.4.6" },
     { name = "rhino-shapley-interop", marker = "extra == 'rhino'", specifier = ">=0.0.4" },
     { name = "rhino3dm", marker = "extra == 'rhino'", specifier = ">=8.17.0" },
-    { name = "rich", extras = ["jupyter"], specifier = ">=13.9.4" },
-    { name = "scipy", specifier = ">=1.14.1" },
-    { name = "shapely", specifier = ">=2.0.7" },
+    { name = "rich", extras = ["jupyter"], specifier = "~=14.0" },
+    { name = "scipy", specifier = "~=1.14" },
+    { name = "shapely", specifier = "~=2.0" },
 ]
 provides-extras = ["numba", "rhino", "dxf", "pardiso"]
 


### PR DESCRIPTION
Updates the `>=` specifiers to `~=`, while omitting the patch version. This allows all versions within the current major release, preventing inadvertent breaking changes (as long as semver is followed).