### PR TITLE
Add phi check for section properties validation

### DIFF
--- a/src/sectionproperties/analysis/section.py
+++ b/src/sectionproperties/analysis/section.py
@@ -299,7 +299,14 @@ class Section:
             i11 = self.section_props.i11_c
             i22 = self.section_props.i22_c
 
-            if ixx is None or iyy is None or ixy is None or i11 is None or i22 is None or phi is None:
+            if (
+                ixx is None
+                or iyy is None
+                or ixy is None
+                or i11 is None
+                or i22 is None
+                or phi is None
+            ):
                 msg = "Section properties failed to save."
                 raise RuntimeError(msg)
 


### PR DESCRIPTION
To avoid a RuntimeError that a argument of type "float | None" cannot be assigned to parameter "phi" of type "float" in function fea.principal_coordinate" ([line 318 in section.py](https://github.com/robbievanleeuwen/section-properties/tree/master/src/sectionproperties/analysis/section.py))
