### PR TITLE
docs: add Quick Start section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,37 @@ You can install `sectionproperties` via [pip] from [PyPI]:
 pip install sectionproperties
 ```
 
+## Quick Start
+
+Analyse a rectangular cross-section and retrieve some key properties:
+
+```python
+from sectionproperties.pre.library import rectangular_section
+from sectionproperties.analysis import Section
+
+# create a 50 x 100 rectangle and mesh it
+geom = rectangular_section(d=100, b=50)
+geom.create_mesh(mesh_sizes=[5])
+
+# run a geometric analysis
+sec = Section(geometry=geom)
+sec.calculate_geometric_properties()
+
+# get some results
+area = sec.get_area()
+ixx_c, iyy_c, ixy_c = sec.get_ic()
+print(f"Area = {area:.0f} mm²")
+print(f"Ixx = {ixx_c:.0f} mm⁴, Iyy = {iyy_c:.0f} mm⁴")
+```
+
+```
+Area = 5000 mm²
+Ixx = 4166667 mm⁴, Iyy = 1041667 mm⁴
+```
+
+See the [documentation][read the docs] for more detailed examples including composite
+sections, warping analysis, and stress calculations.
+
 ## Documentation
 
 `sectionproperties` is fully documented including a user walkthrough, examples,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -49,6 +49,38 @@ Features
 
 See the complete list of ``sectionproperties`` features :ref:`here<label-features>`.
 
+Quick Start
+-----------
+
+Analyse a rectangular cross-section and retrieve some key properties:
+
+.. code:: python
+
+   from sectionproperties.pre.library import rectangular_section
+   from sectionproperties.analysis import Section
+
+   # create a 50 x 100 rectangle and mesh it
+   geom = rectangular_section(d=100, b=50)
+   geom.create_mesh(mesh_sizes=[5])
+
+   # run a geometric analysis
+   sec = Section(geometry=geom)
+   sec.calculate_geometric_properties()
+
+   # get some results
+   area = sec.get_area()
+   ixx_c, iyy_c, ixy_c = sec.get_ic()
+   print(f"Area = {area:.0f} mm²")
+   print(f"Ixx = {ixx_c:.0f} mm⁴, Iyy = {iyy_c:.0f} mm⁴")
+
+.. code:: text
+
+   Area = 5000 mm²
+   Ixx = 4166667 mm⁴, Iyy = 1041667 mm⁴
+
+See the :doc:`examples <examples>` for more detailed walkthroughs including composite
+sections, warping analysis, and stress calculations.
+
 Contributing
 ------------
 


### PR DESCRIPTION
## Summary

Adds a **Quick Start** section to the README between Installation and Documentation, with a minimal working example that:

- Creates a 50×100 mm rectangular section
- Meshes it and runs a geometric analysis
- Retrieves and prints area and second moments of area

Includes expected output so users can verify their installation works. Links to the full docs for more advanced usage.

Closes #585